### PR TITLE
[compile] [parser] refactor parser & add allowUnknownSelectors

### DIFF
--- a/compile_test.go
+++ b/compile_test.go
@@ -351,15 +351,7 @@ func TestOptimizeConstantFolding(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		tokens, err := lex(c.expr)
-		assertNil(t, err)
-
-		cc, err := parseConfig(c.cc, tokens)
-		assertNil(t, err)
-
-		ast, err := parseAstTree(cc, tokens)
-		assertNil(t, err)
-
+		ast, cc, err := newParser(c.cc, c.expr).parse()
 		err = optimizeConstantFolding(cc, ast)
 		if len(c.errMsg) != 0 {
 			assertErrStrContains(t, err, c.errMsg, c)
@@ -554,13 +546,7 @@ func TestOptimizeFastEvaluation(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		tokens, err := lex(c.expr)
-		assertNil(t, err)
-
-		cc, err := parseConfig(c.cc, tokens)
-		assertNil(t, err)
-
-		ast, err := parseAstTree(cc, tokens)
+		ast, cc, err := newParser(c.cc, c.expr).parse()
 		assertNil(t, err)
 
 		optimizeFastEvaluation(cc, ast)
@@ -788,13 +774,7 @@ func TestReordering(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		tokens, err := lex(c.expr)
-		assertNil(t, err)
-
-		cc, err := parseConfig(c.cc, tokens)
-		assertNil(t, err)
-
-		ast, err := parseAstTree(cc, tokens)
+		ast, cc, err := newParser(c.cc, c.expr).parse()
 		assertNil(t, err)
 
 		if c.fastEval {
@@ -963,13 +943,7 @@ func TestOptimize(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		tokens, err := lex(c.expr)
-		assertNil(t, err)
-
-		cc, err := parseConfig(c.cc, tokens)
-		assertNil(t, err)
-
-		ast, err := parseAstTree(cc, tokens)
+		ast, cc, err := newParser(c.cc, c.expr).parse()
 		assertNil(t, err)
 
 		optimize(cc, ast)
@@ -1057,20 +1031,14 @@ func TestCheck(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		tokens, err := lex(c.expr)
-		assertNil(t, err)
-
-		cc, err := parseConfig(c.cc, tokens)
-		assertNil(t, err)
-
-		ast, err := parseAstTree(cc, tokens)
+		ast, cc, err := newParser(c.cc, c.expr).parse()
 		assertNil(t, err)
 
 		if c.optimize {
 			optimize(cc, ast)
 		}
 
-		res := check(cc, ast)
+		res := check(ast)
 
 		if len(c.errMsg) != 0 {
 			assertErrStrContains(t, res.err, c.errMsg, c)

--- a/engine_test.go
+++ b/engine_test.go
@@ -454,7 +454,7 @@ func TestRandomExpression(t *testing.T) {
 		exprs[i] = GenerateRandomExpr((i%level)+1, r, options...)
 
 		if i%step == 0 {
-			t.Log("generating current:", i, (i*100)/size, "%")
+			t.Log("generating... current:", i, (i*100)/size, "%")
 		}
 	}
 
@@ -477,7 +477,7 @@ func TestRandomExpression(t *testing.T) {
 		}
 
 		if i%step == 0 {
-			t.Log("executing current:", i, (i*100)/size, "%")
+			t.Log("executing... current:", i, (i*100)/size, "%")
 			if showSample {
 				fmt.Println(GenerateTestCase(expr, valMap))
 			}

--- a/engine_test.go
+++ b/engine_test.go
@@ -336,6 +336,68 @@ func TestDebugCases(t *testing.T) {
 	}
 }
 
+func TestEval_AllowUnknownSelector(t *testing.T) {
+	testCases := []struct {
+		cc     *CompileConfig
+		expr   string
+		want   Value
+		errMsg string
+		vals   map[string]Value
+	}{
+		{
+			expr:   `(< age 18)`,
+			errMsg: "unknown token error",
+		},
+		{
+			want: false,
+			expr: `(< age 18)`,
+			cc:   &CompileConfig{AllowUnknownSelectors: true},
+			vals: map[string]Value{
+				"age": int64(20),
+			},
+		},
+		{
+			expr:   `(< not_exist_key 18)`,
+			cc:     &CompileConfig{AllowUnknownSelectors: true},
+			errMsg: "selectorKey not exist",
+		},
+		{
+			expr: `
+(-
+ (+ 1
+   (- 2 v3) (/ 6 3) 4)
+ (* 5 -6 7)
+)`,
+			errMsg: "unknown token error",
+		},
+		{
+			want: int64(216),
+			expr: `
+(-
+ (+ 1
+   (- 2 v3) (/ 6 3) 4)
+ (* 5 -6 7)
+)`,
+			cc: &CompileConfig{AllowUnknownSelectors: true},
+			vals: map[string]Value{
+				"v3": int64(3),
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		got, err := Eval(c.cc, c.expr, &Ctx{Selector: NewMapSelector(c.vals)})
+
+		if len(c.errMsg) != 0 {
+			assertErrStrContains(t, err, c.errMsg)
+			continue
+		}
+		assertNil(t, err)
+		assertEquals(t, got, c.want)
+	}
+
+}
+
 func TestRandomExpression(t *testing.T) {
 	const (
 		size       = 5000

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module eval/eval
+module github.com/larry618/eval
 
 go 1.18

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,7 +1,6 @@
 package eval
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -860,11 +859,7 @@ func TestParseAstTree(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-
 		ast, _, err := newParser(c.cc, c.expr).parse()
-		fmt.Println("-------------")
-		fmt.Println(c.expr)
-
 		if len(c.errMsg) != 0 {
 			assertErrStrContains(t, err, c.errMsg, c)
 			continue

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,6 +1,7 @@
 package eval
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -98,7 +99,7 @@ func TestLex(t *testing.T) {
 			expr: `
 (<
  (+ 1
-   (- 2 v3) (/ 6 3) 4)
+   (- 2 v3) (/ -6 3) 4)
  (* 5 6 7)
 )`,
 			tokens: []token{
@@ -114,7 +115,7 @@ func TestLex(t *testing.T) {
 				{typ: rParen, val: ")"},
 				{typ: lParen, val: "("},
 				{typ: ident, val: "/"},
-				{typ: integer, val: "6"},
+				{typ: integer, val: "-6"},
 				{typ: integer, val: "3"},
 				{typ: rParen, val: ")"},
 				{typ: integer, val: "4"},
@@ -249,7 +250,7 @@ func TestLex(t *testing.T) {
      (= 1 1)))
 	(and
      ;; hhhhh3
-	(between age 18 80)
+	(between age 18 -80)
 
     (eq (+ 1 1)        (- 3 1   ) 2)
        
@@ -328,7 +329,7 @@ func TestLex(t *testing.T) {
 				{typ: ident, val: "between"},
 				{typ: ident, val: "age"},
 				{typ: integer, val: "18"},
-				{typ: integer, val: "80"},
+				{typ: integer, val: "-80"},
 				{typ: rParen, val: ")"},
 				{typ: lParen, val: "("},
 				{typ: ident, val: "eq"},
@@ -439,14 +440,23 @@ func TestLex(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		tokens, err := lex(c.expr)
+		p := &parser{source: c.expr}
+		err := p.lex()
 		if len(c.errMsg) != 0 {
 			assertErrStrContains(t, err, c.errMsg, c)
 			continue
 		}
 
 		assertNil(t, err, c)
-		assertEquals(t, tokens, c.tokens)
+
+		assertEquals(t, len(p.tokens), len(c.tokens))
+
+		for i := range p.tokens {
+			t1 := p.tokens[i]
+			t2 := c.tokens[i]
+			assertEquals(t, t1.typ, t2.typ)
+			assertEquals(t, t1.val, t2.val)
+		}
 	}
 }
 
@@ -534,18 +544,16 @@ func TestParseConfig(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		originConf := &CompileConfig{
-			OptimizeOptions: c.origin,
-		}
-		tokens, err := lex(c.expr)
+		p := newParser(&CompileConfig{OptimizeOptions: c.origin}, c.expr)
+		err := p.lex()
 		assertNil(t, err, c)
-		updatedConfig, err := parseConfig(originConf, tokens)
+		err = p.parseConfig()
 		if len(c.errMsg) != 0 {
 			assertErrStrContains(t, err, c.errMsg, c)
 			continue
 		}
 		assertNil(t, err, c)
-		updatedOption := updatedConfig.OptimizeOptions
+		updatedOption := p.conf.OptimizeOptions
 
 		for option, want := range c.want {
 			got, exist := updatedOption[option]
@@ -577,7 +585,7 @@ func TestParseAstTree(t *testing.T) {
 			expr: `
 (<
  (+ 1
-   (- 2 v3) (/ 6 3) 4)
+   (- 2 v3) (/ -6 3) 4)
  (* 5 6 7)
 )`,
 			cc: &CompileConfig{
@@ -606,7 +614,7 @@ func TestParseAstTree(t *testing.T) {
 								tpy:  operator,
 								data: "/",
 								children: []verifyNode{
-									{tpy: value, data: int64(6)},
+									{tpy: value, data: int64(-6)},
 									{tpy: value, data: int64(3)},
 								},
 							},
@@ -790,26 +798,39 @@ func TestParseAstTree(t *testing.T) {
 				},
 			},
 		},
-		// return an error when expr use unregister selector
 		{
+			cc:     &CompileConfig{AllowUnknownSelectors: false},
 			expr:   `(< age 18)`,
 			errMsg: "unknown token error",
+		},
+		// return an error when expr use unregister selector
+		{
+			cc:   &CompileConfig{AllowUnknownSelectors: true},
+			expr: `(< age 18)`,
+			ast: verifyNode{
+				tpy:  operator,
+				data: "<",
+				children: []verifyNode{
+					{tpy: selector, data: "age"},
+					{tpy: value, data: int64(18)},
+				},
+			},
 		},
 		// return an error when expr use unregister operator
 		{
 			expr:   `(is_child 18)`,
-			errMsg: "unknown operator error",
+			errMsg: "unknown token error",
 		},
 		// mismatched element types in the list
 		{
 			expr:   `(17 age 18)`,
-			errMsg: "mismatched list element types error",
+			errMsg: "token type unexpected error",
 		},
 
 		// mismatched element types in the list
 		{
 			expr:   `(17 18 "19")`,
-			errMsg: "mismatched list element types error",
+			errMsg: "token type unexpected error",
 		},
 
 		{
@@ -823,26 +844,33 @@ func TestParseAstTree(t *testing.T) {
 		},
 
 		{
+			expr:   `(< 12 18`,
+			errMsg: "parentheses unmatched error",
+		},
+
+		{
 			expr:   `(+ 1 1 ))`,
 			errMsg: "parentheses unmatched error",
 		},
 
 		{
 			expr:   `(+ 1 1) (+ 1 1)`,
-			errMsg: "invalid expression error",
+			errMsg: "parentheses unmatched error",
 		},
 	}
 
 	for _, c := range testCases {
-		tokens, err := lex(c.expr)
-		assertNil(t, err, c)
-		ast, err := parseAstTree(c.cc, tokens)
+
+		ast, _, err := newParser(c.cc, c.expr).parse()
+		fmt.Println("-------------")
+		fmt.Println(c.expr)
 
 		if len(c.errMsg) != 0 {
 			assertErrStrContains(t, err, c.errMsg, c)
 			continue
 		}
 
+		assertNil(t, err)
 		assertAstTreeIdentical(t, ast, c.ast, c)
 	}
 }


### PR DESCRIPTION
This PR refactors the parser and adds support for allowing the use of unknown selectors


## Test

```
PASS
ok  	github.com/larry618/eval	3.503s
```

```
❯ go test -run='TestRandomExpression' -v
=== RUN   TestRandomExpression
    engine_test.go:457: generating... current: 0 0 %
    engine_test.go:457: generating... current: 50000 10 %
    engine_test.go:457: generating... current: 100000 20 %
    engine_test.go:457: generating... current: 150000 30 %
    engine_test.go:457: generating... current: 200000 40 %
    engine_test.go:457: generating... current: 250000 50 %
    engine_test.go:457: generating... current: 300000 60 %
    engine_test.go:457: generating... current: 350000 70 %
    engine_test.go:457: generating... current: 400000 80 %
    engine_test.go:457: generating... current: 450000 90 %
    engine_test.go:480: executing... current: 0 0 %
    engine_test.go:480: executing... current: 50000 10 %
    engine_test.go:480: executing... current: 100000 20 %
    engine_test.go:480: executing... current: 150000 30 %
    engine_test.go:480: executing... current: 200000 40 %
    engine_test.go:480: executing... current: 250000 50 %
    engine_test.go:480: executing... current: 300000 60 %
    engine_test.go:480: executing... current: 350000 70 %
    engine_test.go:480: executing... current: 400000 80 %
    engine_test.go:480: executing... current: 450000 90 %
--- PASS: TestRandomExpression (292.94s)
PASS
ok  	eval/eval	293.994s
```