### PR TITLE
[util] [test] parallelize TestRandomExpressions

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -118,6 +118,7 @@ func setExtraInfo(e *Expr) {
 	calAndSetStackSize(e)
 	calAndSetShortCircuit(e)
 }
+
 func calAndSetParentIndex(e *Expr) {
 	size := len(e.nodes)
 	f := make([]int, size)

--- a/engine_test.go
+++ b/engine_test.go
@@ -418,7 +418,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 
 }
 
-func TestRandomExpression(t *testing.T) {
+func TestRandomExpressions(t *testing.T) {
 	const (
 		size       = 100000
 		level      = 53

--- a/engine_test.go
+++ b/engine_test.go
@@ -2,10 +2,13 @@ package eval
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -32,6 +35,22 @@ func TestDebugCases(t *testing.T) {
 		want          Value
 		run           runThis
 	}{
+
+		{
+			want:          int64(-1),
+			optimizeLevel: disable,
+			s:             "(if less -1 1)",
+			valMap: map[string]Value{
+				"less": true,
+			},
+		},
+
+		{
+			want:          int64(2),
+			optimizeLevel: disable,
+			s:             "(+ 1 1)",
+			valMap:        nil,
+		},
 		{
 			run:           ________RunThisOne________,
 			want:          true,
@@ -59,6 +78,7 @@ func TestDebugCases(t *testing.T) {
 				"F": false,
 			},
 		},
+
 		{
 			run:           ________RunThisOne________,
 			want:          false,
@@ -400,17 +420,31 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 
 func TestRandomExpression(t *testing.T) {
 	const (
-		size       = 5000
+		size       = 100000
 		level      = 53
 		step       = size / 100
 		showSample = false
 	)
 
-	exprs := make([]GenExprResult, size)
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	const (
+		producerCount = 200
+		consumerCount = 1000
+		bufferSize    = 10000
+	)
 
-	cc := NewCompileConfig()
-	cc.SelectorMap = map[string]SelectorKey{
+	var (
+		r         = rand.New(rand.NewSource(time.Now().UnixNano()))
+		m         sync.Mutex
+		randomInt = func(n int) int {
+			m.Lock()
+			i := r.Intn(n)
+			m.Unlock()
+			return i
+		}
+	)
+
+	conf := NewCompileConfig()
+	conf.SelectorMap = map[string]SelectorKey{
 		"select_true":  SelectorKey(1),
 		"select_false": SelectorKey(2),
 	}
@@ -420,7 +454,7 @@ func TestRandomExpression(t *testing.T) {
 		"select_false": false,
 	}
 	for i := 0; i < 20; i++ {
-		v := r.Intn(200) - 100
+		v := randomInt(200) - 100
 		var k string
 		if v < 0 {
 			k = "select_neg_" + strconv.Itoa(-v)
@@ -428,44 +462,92 @@ func TestRandomExpression(t *testing.T) {
 			k = "select_" + strconv.Itoa(v)
 		}
 		valMap[k] = int64(v)
-		_ = GetOrRegisterKey(cc, k)
+		_ = GetOrRegisterKey(conf, k)
 	}
 
-	ctx := NewCtxWithMap(cc, valMap)
-
-	for i := 0; i < size; i++ {
-		options := make([]GenExprOption, 0, 4)
-		v := r.Intn(0b1000)
-
-		if v&0b001 != 0 {
-			options = append(options, GenType(Bool))
-		} else {
-			options = append(options, GenType(Number))
-		}
-
-		if v&0b010 != 0 {
-			options = append(options, EnableCondition)
-		}
-
-		if v&0b100 != 0 {
-			options = append(options, EnableSelector, GenSelectors(valMap))
-		}
-
-		exprs[i] = GenerateRandomExpr((i%level)+1, r, options...)
-
-		if i%step == 0 {
-			t.Log("generating... current:", i, (i*100)/size, "%")
-		}
+	type execRes struct {
+		expr GenExprResult
+		got  Value
+		err  error
 	}
 
-	for i, expr := range exprs {
-		v := r.Intn(0b1000)
-		// combination of optimizations
-		cc.OptimizeOptions[Reordering] = v&0b1 != 0
-		cc.OptimizeOptions[FastEvaluation] = v&0b10 != 0
-		cc.OptimizeOptions[ConstantFolding] = v&0b100 != 0
+	exprChan := make(chan GenExprResult, bufferSize)
+	resChan := make(chan execRes, bufferSize)
 
-		got, err := Eval(cc, expr.Expr, ctx)
+	var pwg sync.WaitGroup
+
+	var cnt int32
+	for p := 0; p < producerCount; p++ {
+		pwg.Add(1)
+		go func() {
+			defer pwg.Done()
+			for atomic.LoadInt32(&cnt) < size {
+				options := make([]GenExprOption, 0, 4)
+				v := randomInt(0b1000)
+
+				if v&0b001 != 0 {
+					options = append(options, GenType(Bool))
+				} else {
+					options = append(options, GenType(Number))
+				}
+
+				if v&0b010 != 0 {
+					options = append(options, EnableCondition)
+				}
+
+				if v&0b100 != 0 {
+					options = append(options, EnableSelector, GenSelectors(valMap))
+				}
+
+				random := rand.New(rand.NewSource(int64(randomInt(math.MaxInt))))
+
+				i := int(atomic.AddInt32(&cnt, 1))
+				exprChan <- GenerateRandomExpr((i%level)+1, random, options...)
+				if i%step == 0 {
+					t.Log("generating... current:", i, (i*100)/size, "%")
+				}
+			}
+		}()
+	}
+
+	go func() {
+		pwg.Wait()
+		close(exprChan)
+	}()
+
+	var cwg sync.WaitGroup
+	for c := 0; c < consumerCount; c++ {
+		cwg.Add(1)
+		go func() {
+			defer cwg.Done()
+			for expr := range exprChan {
+				v := randomInt(0b1000)
+				// combination of optimizations
+				cc := CopyCompileConfig(conf)
+				cc.OptimizeOptions[Reordering] = v&0b1 != 0
+				cc.OptimizeOptions[FastEvaluation] = v&0b10 != 0
+				cc.OptimizeOptions[ConstantFolding] = v&0b100 != 0
+				ctx := NewCtxWithMap(cc, valMap)
+				got, err := Eval(cc, expr.Expr, ctx)
+
+				resChan <- execRes{
+					expr: expr,
+					got:  got,
+					err:  err,
+				}
+			}
+		}()
+	}
+
+	go func() {
+		cwg.Wait()
+		close(resChan)
+	}()
+
+	var i int
+	for res := range resChan {
+		i++
+		expr, got, err := res.expr, res.got, res.err
 		if err != nil {
 			fmt.Println(GenerateTestCase(expr, valMap))
 			t.Fatalf("assertNil failed, got: %+v\n", err)
@@ -477,10 +559,11 @@ func TestRandomExpression(t *testing.T) {
 		}
 
 		if i%step == 0 {
-			t.Log("executing... current:", i, (i*100)/size, "%")
+			t.Log("executing.... current:", i, (i*100)/size, "%")
 			if showSample {
 				fmt.Println(GenerateTestCase(expr, valMap))
 			}
+			//t.Logf("Channel status: %% exprChan: %d, resChan: %d\n", len(exprChan), len(resChan))
 		}
 	}
 }


### PR DESCRIPTION
This PR parallelizes `TestRandomExpressions`, using Producer-consumer model to reduce execution time. Now it takes about 150 seconds to generate and execute **one million** expressions

## Test
```bash
❯ go test -run='TestRandomExpression' -v
=== RUN   TestRandomExpression
    engine_test.go:507: generating... current: 100000 10 %
    engine_test.go:562: executing.... current: 100000 10 %
    engine_test.go:507: generating... current: 200000 20 %
    engine_test.go:562: executing.... current: 200000 20 %
    engine_test.go:507: generating... current: 300000 30 %
    engine_test.go:562: executing.... current: 300000 30 %
    engine_test.go:507: generating... current: 400000 40 %
    engine_test.go:562: executing.... current: 400000 40 %
    engine_test.go:507: generating... current: 500000 50 %
    engine_test.go:562: executing.... current: 500000 50 %
    engine_test.go:507: generating... current: 600000 60 %
    engine_test.go:562: executing.... current: 600000 60 %
    engine_test.go:507: generating... current: 700000 70 %
    engine_test.go:562: executing.... current: 700000 70 %
    engine_test.go:507: generating... current: 800000 80 %
    engine_test.go:562: executing.... current: 800000 80 %
    engine_test.go:507: generating... current: 900000 90 %
    engine_test.go:562: executing.... current: 900000 90 %
    engine_test.go:507: generating... current: 1000000 100 %
    engine_test.go:562: executing.... current: 1000000 100 %
--- PASS: TestRandomExpression (140.71s)
PASS
ok  	github.com/larry618/eval	141.214s
```