### PR TITLE
[engine] [compile] update node struct

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -125,12 +125,13 @@ func calAndSetParentIndex(e *Expr) {
 	f[0] = -1
 
 	for i := 0; i < size; i++ {
-		cCnt := int(e.childCounts[i])
+		n := e.nodes[i]
+		cCnt := int(n.childCnt)
 		if cCnt == 0 {
 			continue
 		}
-		sIdx := int(e.childStartIndex[i])
-		for j := sIdx; j < sIdx+cCnt; j++ {
+		cIdx := int(n.childIdx)
+		for j := cIdx; j < cIdx+cCnt; j++ {
 			f[j] = i
 		}
 	}
@@ -140,7 +141,8 @@ func calAndSetParentIndex(e *Expr) {
 
 func calAndSetStackSize(e *Expr) {
 	var isLeaf = func(e *Expr, idx int) bool {
-		return e.childCounts[idx] == 0 || e.nodes[idx].flag&nodeTypeMask == fastOperator
+		n := e.nodes[idx]
+		return n.childCnt == 0 || n.flag&nodeTypeMask == fastOperator
 	}
 
 	var isCondNode = func(e *Expr, idx int) bool {
@@ -149,7 +151,7 @@ func calAndSetStackSize(e *Expr) {
 
 	var isFirstChild = func(e *Expr, idx int) bool {
 		parentIdx := e.parentIndex[idx]
-		return int(e.childStartIndex[parentIdx]) == idx
+		return int(e.nodes[parentIdx].childIdx) == idx
 
 	}
 
@@ -164,7 +166,7 @@ func calAndSetStackSize(e *Expr) {
 		if isLeaf(e, parentIdx) {
 			f1[i] = f1[parentIdx]
 		} else {
-			siblingCount := int(e.childStartIndex[parentIdx]) + int(e.childCounts[parentIdx]) - 1 - i
+			siblingCount := int(e.nodes[parentIdx].childIdx) + int(e.nodes[parentIdx].childCnt) - 1 - i
 			// f[i] = f[pIdx] + right sibling count + 1
 
 			if isCondNode(e, parentIdx) {
@@ -195,11 +197,11 @@ func calAndSetStackSize(e *Expr) {
 
 		if isLeaf(e, i) {
 			// f[i] = f[pIdx] + left sibling count + 1
-			siblingCount := i - int(e.childStartIndex[parentIdx])
+			siblingCount := i - int(e.nodes[parentIdx].childIdx)
 			f2[i] = f2[parentIdx] + siblingCount + 1
 		} else {
 			// f[i] = f[pIdx] + left sibling count
-			siblingCount := i - int(e.childStartIndex[parentIdx])
+			siblingCount := i - int(e.nodes[parentIdx].childIdx)
 			f2[i] = f2[parentIdx] + siblingCount
 		}
 	}
@@ -224,26 +226,13 @@ func calAndSetShortCircuit(e *Expr) {
 			return false
 		}
 
-		cnt := int(e.childCounts[parentIdx])
-		startIdx := int(e.childStartIndex[parentIdx])
-		if startIdx+cnt-1 == idx {
+		cnt := int(e.nodes[parentIdx].childCnt)
+		childIdx := int(e.nodes[parentIdx].childIdx)
+		if childIdx+cnt-1 == idx {
 			return true
 		}
 		return false
 	}
-
-	var isFirstChild = func(n *node) bool {
-		idx := int(n.idx)
-		parentIdx := e.parentIndex[idx]
-		if parentIdx == -1 {
-			return false
-		}
-
-		startIdx := int(e.childStartIndex[parentIdx])
-		return idx == startIdx
-	}
-
-	_ = isFirstChild
 
 	var parentNode = func(n *node) *node {
 		parentIdx := e.parentIndex[int(n.idx)]
@@ -289,9 +278,7 @@ func calAndSetShortCircuit(e *Expr) {
 		}
 	}
 
-	for i, n := range e.nodes {
-		n.scIdx = int16(f[i])
-	}
+	e.scIdx = f
 }
 
 func optimize(cc *CompileConfig, root *astNode) {
@@ -504,8 +491,8 @@ func optimizeFastEvaluation(cc *CompileConfig, root *astNode) {
 	for _, child := range root.children {
 		optimizeFastEvaluation(cc, child)
 	}
-	node := root.node
-	if (node.flag & nodeTypeMask) != operator {
+	n := root.node
+	if (n.flag & nodeTypeMask) != operator {
 		return
 	}
 
@@ -559,9 +546,7 @@ func check(root *astNode) checkRes {
 
 func compress(root *astNode, size int) *Expr {
 	e := &Expr{
-		nodes:           make([]*node, 0, size),
-		childCounts:     make([]int8, 0, size),
-		childStartIndex: make([]int16, 0, size),
+		nodes: make([]*node, 0, size),
 	}
 	queue := make([]*astNode, 0, size)
 	queue = append(queue, root)
@@ -569,7 +554,7 @@ func compress(root *astNode, size int) *Expr {
 	idx := 0
 	for idx < len(queue) {
 		curt := queue[idx]
-		e.appendNode(curt, len(queue))
+		e.appendNode(curt.node, len(queue), len(curt.children))
 		for _, child := range curt.children {
 			queue = append(queue, child)
 		}
@@ -578,14 +563,14 @@ func compress(root *astNode, size int) *Expr {
 	return e
 }
 
-func (e *Expr) appendNode(n *astNode, childStartIdx int) {
-	n.node.idx = int16(len(e.nodes))
-	e.nodes = append(e.nodes, n.node)
-	e.childCounts = append(e.childCounts, int8(len(n.children)))
-	switch n.node.getNodeType() {
+func (e *Expr) appendNode(n *node, childIndex int, childCnt int) {
+	n.idx = int16(len(e.nodes))
+	n.childCnt = int8(childCnt)
+	switch n.getNodeType() {
 	case value, selector:
-		e.childStartIndex = append(e.childStartIndex, -1)
+		n.childIdx = -1
 	default:
-		e.childStartIndex = append(e.childStartIndex, int16(childStartIdx))
+		n.childIdx = int16(childIndex)
 	}
+	e.nodes = append(e.nodes, n)
 }

--- a/compile.go
+++ b/compile.go
@@ -61,7 +61,7 @@ type CompileConfig struct {
 	AllowUnknownSelectors bool
 }
 
-func (cc *CompileConfig) getCosts(nodeType uint16, nodeName string) int {
+func (cc *CompileConfig) getCosts(nodeType uint8, nodeName string) int {
 	const (
 		defaultCost  = 5
 		selectorCost = 7
@@ -265,7 +265,7 @@ func calAndSetShortCircuit(e *Expr) {
 			f[i] = i
 			continue
 		}
-		var flag uint16
+		var flag uint8
 		switch {
 		case isLastChild(n):
 			flag |= scIfTrue
@@ -517,7 +517,7 @@ func optimizeFastEvaluation(cc *CompileConfig, root *astNode) {
 		return
 	}
 
-	otherPartMask := nodeTypeMask ^ uint16(0b11111111)
+	otherPartMask := nodeTypeMask ^ uint8(0b11111111)
 
 	root.node.flag = fastOperator | (root.node.flag & otherPartMask)
 }

--- a/compile_test.go
+++ b/compile_test.go
@@ -352,6 +352,7 @@ func TestOptimizeConstantFolding(t *testing.T) {
 
 	for _, c := range testCases {
 		ast, cc, err := newParser(c.cc, c.expr).parse()
+		assertNil(t, err, c)
 		err = optimizeConstantFolding(cc, ast)
 		if len(c.errMsg) != 0 {
 			assertErrStrContains(t, err, c.errMsg, c)

--- a/engine.go
+++ b/engine.go
@@ -15,21 +15,21 @@ type (
 
 const (
 	// node types
-	nodeTypeMask = uint16(0b111)
-	value        = uint16(0b001)
-	selector     = uint16(0b010)
-	operator     = uint16(0b011)
-	fastOperator = uint16(0b100)
-	cond         = uint16(0b101)
-	end          = uint16(0b110)
+	nodeTypeMask = uint8(0b111)
+	value        = uint8(0b001)
+	selector     = uint8(0b010)
+	operator     = uint8(0b011)
+	fastOperator = uint8(0b100)
+	cond         = uint8(0b101)
+	end          = uint8(0b110)
 
 	// short circuit flag
-	scIfFalse = uint16(0b001000)
-	scIfTrue  = uint16(0b010000)
+	scIfFalse = uint8(0b001000)
+	scIfTrue  = uint8(0b010000)
 )
 
 type node struct {
-	flag     uint16
+	flag     uint8
 	idx      int16
 	scIdx    int16
 	selKey   SelectorKey
@@ -37,7 +37,7 @@ type node struct {
 	operator Operator
 }
 
-func (n *node) getNodeType() uint16 {
+func (n *node) getNodeType() uint8 {
 	return n.flag & nodeTypeMask
 }
 

--- a/engine.go
+++ b/engine.go
@@ -46,10 +46,10 @@ type Expr struct {
 	maxStackSize int16
 	nodes        []*node
 	// extra info
-	parentIndex []int
-	scIdx       []int
-	sfSize      []int
-	osSize      []int
+	parentIdx []int
+	scIdx     []int
+	sfSize    []int
+	osSize    []int
 }
 
 func EvalBool(conf *CompileConfig, expr string, ctx *Ctx) (bool, error) {
@@ -161,7 +161,7 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 
 			res, err = curt.operator(ctx, param)
 			if debug {
-				printOperatorFunc(curt.value, param, res, err)
+				printOperator(curt.value, param, res, err)
 			}
 			if err != nil {
 				return nil, fmt.Errorf("eval error [%w], Operator: %v", err, curt.value)
@@ -199,7 +199,7 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 			}
 			res, err = curt.operator(ctx, param)
 			if debug {
-				printOperatorFunc(curt.value, param, res, err)
+				printOperator(curt.value, param, res, err)
 			}
 			if err != nil {
 				return nil, fmt.Errorf("eval error [%w], Operator: %v", err, curt.value)
@@ -351,7 +351,7 @@ func printStacks(maxId int, os []Value, osTop int, sf []*node, sfTop int) {
 	fmt.Println(sb.String())
 }
 
-func printOperatorFunc(op Value, params []Value, res Value, err error) {
+func printOperator(op Value, params []Value, res Value, err error) {
 	fmt.Printf("invoke operator, op: %v, params: %v, res: %v, err: %v\n\n", op, params, res, err)
 }
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -419,7 +419,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 100000
+		size          = 200000
 		level         = 53
 		step          = size / 100
 		showSample    = false

--- a/engine_test.go
+++ b/engine_test.go
@@ -51,7 +51,6 @@ func TestDebugCases(t *testing.T) {
 			valMap:        nil,
 		},
 		{
-			run:           ________RunThisOne________,
 			want:          true,
 			optimizeLevel: disable,
 			s: `
@@ -79,7 +78,6 @@ func TestDebugCases(t *testing.T) {
 		},
 
 		{
-			run:           ________RunThisOne________,
 			want:          false,
 			optimizeLevel: disable,
 			s: `
@@ -93,6 +91,7 @@ func TestDebugCases(t *testing.T) {
 			},
 		},
 		{
+			run:           ________RunThisOne________,
 			want:          true,
 			optimizeLevel: disable,
 			s: `

--- a/engine_test.go
+++ b/engine_test.go
@@ -2,7 +2,6 @@ package eval
 
 import (
 	"fmt"
-	"math"
 	"math/rand"
 	"reflect"
 	"strconv"
@@ -420,28 +419,20 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size       = 100000
-		level      = 53
-		step       = size / 100
-		showSample = false
+		size          = 100000
+		level         = 53
+		step          = size / 100
+		showSample    = false
+		printProgress = true
 	)
 
 	const (
-		producerCount = 200
-		consumerCount = 1000
+		producerCount = 400
+		consumerCount = 2000
 		bufferSize    = 10000
 	)
 
-	var (
-		r         = rand.New(rand.NewSource(time.Now().UnixNano()))
-		m         sync.Mutex
-		randomInt = func(n int) int {
-			m.Lock()
-			i := r.Intn(n)
-			m.Unlock()
-			return i
-		}
-	)
+	var random = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	conf := NewCompileConfig()
 	conf.SelectorMap = map[string]SelectorKey{
@@ -454,7 +445,7 @@ func TestRandomExpressions(t *testing.T) {
 		"select_false": false,
 	}
 	for i := 0; i < 20; i++ {
-		v := randomInt(200) - 100
+		v := random.Intn(200) - 100
 		var k string
 		if v < 0 {
 			k = "select_neg_" + strconv.Itoa(-v)
@@ -472,18 +463,18 @@ func TestRandomExpressions(t *testing.T) {
 	}
 
 	exprChan := make(chan GenExprResult, bufferSize)
-	resChan := make(chan execRes, bufferSize)
+	verifyChan := make(chan execRes, bufferSize)
 
 	var pwg sync.WaitGroup
 
-	var cnt int32
+	var genCnt int32
 	for p := 0; p < producerCount; p++ {
 		pwg.Add(1)
-		go func() {
+		go func(r *rand.Rand) {
 			defer pwg.Done()
-			for atomic.LoadInt32(&cnt) < size {
+			for atomic.LoadInt32(&genCnt) < size {
 				options := make([]GenExprOption, 0, 4)
-				v := randomInt(0b1000)
+				v := random.Intn(0b1000)
 
 				if v&0b001 != 0 {
 					options = append(options, GenType(Bool))
@@ -499,15 +490,13 @@ func TestRandomExpressions(t *testing.T) {
 					options = append(options, EnableSelector, GenSelectors(valMap))
 				}
 
-				random := rand.New(rand.NewSource(int64(randomInt(math.MaxInt))))
-
-				i := int(atomic.AddInt32(&cnt, 1))
-				exprChan <- GenerateRandomExpr((i%level)+1, random, options...)
+				i := int(atomic.AddInt32(&genCnt, 1))
+				exprChan <- GenerateRandomExpr((i%level)+1, r, options...)
 				if i%step == 0 {
 					t.Log("generating... current:", i, (i*100)/size, "%")
 				}
 			}
-		}()
+		}(rand.New(rand.NewSource(random.Int63())))
 	}
 
 	go func() {
@@ -518,10 +507,10 @@ func TestRandomExpressions(t *testing.T) {
 	var cwg sync.WaitGroup
 	for c := 0; c < consumerCount; c++ {
 		cwg.Add(1)
-		go func() {
+		go func(r *rand.Rand) {
 			defer cwg.Done()
 			for expr := range exprChan {
-				v := randomInt(0b1000)
+				v := r.Intn(0b1000)
 				// combination of optimizations
 				cc := CopyCompileConfig(conf)
 				cc.OptimizeOptions[Reordering] = v&0b1 != 0
@@ -530,22 +519,25 @@ func TestRandomExpressions(t *testing.T) {
 				ctx := NewCtxWithMap(cc, valMap)
 				got, err := Eval(cc, expr.Expr, ctx)
 
-				resChan <- execRes{
+				verifyChan <- execRes{
 					expr: expr,
 					got:  got,
 					err:  err,
 				}
 			}
-		}()
+		}(rand.New(rand.NewSource(random.Int63())))
 	}
 
 	go func() {
 		cwg.Wait()
-		close(resChan)
+		close(verifyChan)
 	}()
 
+	const line = "----------"
+
+	prev := time.Now()
 	var i int
-	for res := range resChan {
+	for res := range verifyChan {
 		i++
 		expr, got, err := res.expr, res.got, res.err
 		if err != nil {
@@ -563,7 +555,16 @@ func TestRandomExpressions(t *testing.T) {
 			if showSample {
 				fmt.Println(GenerateTestCase(expr, valMap))
 			}
-			//t.Logf("Channel status: %% exprChan: %d, resChan: %d\n", len(exprChan), len(resChan))
+			if printProgress {
+				if i == step {
+					fmt.Printf("|%10s|%10s|%10s|%10s|%10s|%10s|%10s|\n", "gen progs", "exec progs", "gen count", "exec count", "gen chan", "exec chan", "time")
+					fmt.Printf("|%10s|%10s|%10s|%10s|%10s|%10s|%10s|\n", line, line, line, line, line, line, line)
+				}
+
+				j := atomic.LoadInt32(&genCnt)
+				fmt.Printf("|%8d %%|%8d %%|%10d|%10d|%10d|%10d|%10s|\n", (j*100)/size, (i*100)/size, j, i, len(exprChan), len(verifyChan), time.Since(prev).Truncate(time.Millisecond))
+				prev = time.Now()
+			}
 		}
 	}
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type verifyNode struct {
-	tpy       uint16
+	tpy       uint8
 	data      Value
 	cost      int
 	selectKey SelectorKey

--- a/util.go
+++ b/util.go
@@ -465,7 +465,7 @@ func PrintExpr(expr *Expr, fields ...string) string {
 			return e.nodes[i].value
 		},
 		pIdx: func(e *Expr, i int) Value {
-			return e.parentIndex[i]
+			return e.parentIdx[i]
 		},
 		flag: func(e *Expr, i int) Value {
 			f := e.nodes[i].flag

--- a/util.go
+++ b/util.go
@@ -368,15 +368,14 @@ func PrintCode(e *Expr) string {
 	var helper func(*node) (string, bool)
 
 	helper = func(root *node) (string, bool) {
-		idx := root.idx
-		if e.childCounts[idx] == 0 {
+		if root.childCnt == 0 {
 			return printLeafNode(root)
 		}
 
 		var sb strings.Builder
 		sb.WriteString(fmt.Sprintf("(%v", root.value))
-		for i := 0; i < int(e.childCounts[idx]); i++ {
-			childIdx := int(e.childStartIndex[idx]) + i
+		for i := 0; i < int(root.childCnt); i++ {
+			childIdx := int(root.childIdx) + i
 			child := e.nodes[childIdx]
 			cc, isLeaf := helper(child)
 			if isLeaf {
@@ -486,13 +485,13 @@ func PrintExpr(expr *Expr, fields ...string) string {
 			return res
 		},
 		cCnt: func(e *Expr, i int) Value {
-			return e.childCounts[i]
+			return e.nodes[i].childCnt
 		},
 		cIdx: func(e *Expr, i int) Value {
-			return e.childStartIndex[i]
+			return e.nodes[i].childIdx
 		},
 		scIdx: func(e *Expr, i int) Value {
-			return e.nodes[i].scIdx
+			return e.scIdx[i]
 		},
 		scVal: func(e *Expr, i int) Value {
 			f := e.nodes[i].flag


### PR DESCRIPTION
This PR updates struct layout of `node` to make important fields more dense in memory.

## Test
```
❯ go test
PASS
ok  	github.com/larry618/eval	1.611s
```

```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     39342|     30000|      6806|       140|    2.223s|
|       2 %|       2 %|     62676|     60000|        20|       257|    3.428s|
|       3 %|       3 %|     92573|     90000|        88|        85|    4.079s|
|       4 %|       4 %|    123169|    120000|       742|        28|    4.159s|
|       5 %|       5 %|    152530|    150000|        49|        81|    4.124s|
|       6 %|       6 %|    182493|    180000|         0|        93|    4.116s|
|       7 %|       7 %|    212348|    210000|         0|         0|    4.115s|
|       8 %|       8 %|    242699|    240000|       286|        14|    4.255s|
|       9 %|       9 %|    272568|    270000|        13|       157|    4.212s|
|      10 %|      10 %|    303196|    300000|       724|        72|    4.367s|
|      11 %|      11 %|    332622|    330000|        47|       175|    4.247s|
|      12 %|      12 %|    362486|    360000|        61|        26|    4.279s|
|      13 %|      13 %|    392607|    390000|        63|       145|    4.353s|
|      14 %|      14 %|    422621|    420000|       175|        48|    4.546s|
|      15 %|      15 %|    452573|    450000|       171|         4|    4.301s|
|      16 %|      16 %|    482558|    480000|       126|        32|    4.399s|
|      17 %|      17 %|    512446|    510000|        37|        10|      4.5s|
|      18 %|      18 %|    542766|    540000|       257|       109|    4.351s|
|      19 %|      19 %|    572599|    570000|       101|       100|    4.471s|
|      20 %|      20 %|    602662|    600000|       154|       109|    4.395s|
|      21 %|      21 %|    633179|    630000|       585|       197|    4.381s|
|      22 %|      22 %|    662422|    660000|         0|        26|    4.472s|
|      23 %|      23 %|    692915|    690000|       417|        99|    4.344s|
|      24 %|      24 %|    722600|    720000|        67|       138|    4.192s|
|      25 %|      25 %|    752478|    750000|         0|        79|    4.294s|
|      26 %|      26 %|    783710|    780000|      1171|       140|    4.249s|
|      27 %|      27 %|    812740|    810000|       170|       170|    4.192s|
|      28 %|      28 %|    842777|    840000|       375|         2|    4.371s|
|      29 %|      29 %|    872428|    870000|        11|        19|    4.858s|
|      30 %|      30 %|    902525|    900000|        55|        75|    4.988s|
|      31 %|      31 %|    952399|    930000|     10000|     10000|    7.244s|
|      32 %|      32 %|    966926|    960000|      4301|       227|    2.862s|
|      33 %|      33 %|    992521|    990000|        99|        22|    4.691s|
|      34 %|      34 %|   1022945|   1020000|       326|       224|    4.896s|
|      35 %|      35 %|   1052521|   1050000|       122|         1|    4.652s|
|      36 %|      36 %|   1082736|   1080000|       169|       167|    4.936s|
|      37 %|      37 %|   1112828|   1110000|       185|       244|    4.662s|
|      38 %|      38 %|   1142925|   1140000|       429|        96|    4.547s|
|      39 %|      39 %|   1172604|   1170000|       135|        69|    4.546s|
|      40 %|      40 %|   1202616|   1200000|       170|        47|    4.671s|
|      41 %|      41 %|   1232511|   1230000|        65|        49|    4.734s|
|      42 %|      42 %|   1262923|   1260000|       506|        20|    4.775s|
|      43 %|      43 %|   1292453|   1290000|        40|        13|     4.76s|
|      44 %|      44 %|   1322392|   1320000|         0|         0|    4.632s|
|      45 %|      45 %|   1353513|   1350000|      1043|        72|     4.57s|
|      46 %|      46 %|   1382915|   1380000|       413|       104|    4.774s|
|      47 %|      47 %|   1413328|   1410000|       743|       185|    4.802s|
|      48 %|      48 %|   1442597|   1440000|        11|       187|    4.659s|
|      49 %|      49 %|   1472754|   1470000|       343|        13|      4.7s|
|      50 %|      50 %|   1503334|   1500000|       832|       103|     4.72s|
|      51 %|      51 %|   1532310|   1530000|         0|         0|    4.642s|
|      52 %|      52 %|   1562432|   1560000|        27|         7|    4.656s|
|      53 %|      53 %|   1592576|   1590000|       142|        35|    4.871s|
|      54 %|      54 %|   1622567|   1620000|       164|         4|    4.671s|
|      55 %|      55 %|   1652583|   1650000|       143|        42|    4.775s|
|      56 %|      56 %|   1682480|   1680000|        58|        24|    4.753s|
|      57 %|      57 %|   1713908|   1710000|      1406|       103|    4.624s|
|      58 %|      58 %|   1745366|   1740000|      2858|       108|    4.621s|
|      59 %|      59 %|   1772519|   1770000|         0|       127|      4.7s|
|      60 %|      60 %|   1802457|   1800000|        50|         8|    4.627s|
|      61 %|      61 %|   1833285|   1830000|       714|       172|    4.778s|
|      62 %|      62 %|   1862557|   1860000|        93|        64|    4.828s|
|      63 %|      63 %|   1897766|   1890000|      5252|       115|    4.694s|
|      64 %|      64 %|   1922816|   1920000|       411|         5|    4.586s|
|      65 %|      65 %|   1952856|   1950000|       411|        46|    4.661s|
|      66 %|      66 %|   1982604|   1980000|       200|         5|    4.696s|
|      67 %|      67 %|   2012395|   2010000|         0|         0|    4.603s|
|      68 %|      68 %|   2042761|   2040000|       252|       111|    4.756s|
|      69 %|      69 %|   2073188|   2070000|       725|        64|    4.731s|
|      70 %|      70 %|   2104099|   2100000|      1684|        18|    4.671s|
|      71 %|      71 %|   2132545|   2130000|        92|        54|    4.467s|
|      72 %|      72 %|   2163671|   2160000|      1226|        45|    4.924s|
|      73 %|      73 %|   2192872|   2190000|       455|        18|    4.963s|
|      74 %|      74 %|   2222492|   2220000|        19|        74|    5.741s|
|      75 %|      75 %|   2253163|   2250000|       682|        82|    5.908s|
|      76 %|      76 %|   2282523|   2280000|       119|         7|    5.594s|
|      77 %|      77 %|   2312506|   2310000|        69|        40|    6.158s|
|      78 %|      78 %|   2343048|   2340000|       404|       246|     6.09s|
|      79 %|      79 %|   2372572|   2370000|       112|        62|    5.592s|
|      80 %|      80 %|   2402460|   2400000|        55|        10|    5.178s|
|      81 %|      81 %|   2433105|   2430000|         0|       712|    4.903s|
|      82 %|      82 %|   2462460|   2460000|        10|        52|    4.994s|
|      83 %|      83 %|   2492854|   2490000|       294|       160|     5.28s|
|      84 %|      84 %|   2522524|   2520000|         0|       127|    5.261s|
|      85 %|      85 %|   2552825|   2550000|       233|       194|    4.789s|
|      86 %|      86 %|   2582573|   2580000|       120|        53|    4.556s|
|      87 %|      87 %|   2612611|   2610000|        18|       193|    5.297s|
|      88 %|      88 %|   2643315|   2640000|       690|       230|    5.846s|
|      89 %|      89 %|   2672634|   2670000|       226|         9|    4.907s|
|      90 %|      90 %|   2704425|   2700000|      2028|         0|    5.561s|
|      91 %|      91 %|   2733295|   2730000|       152|       744|    5.347s|
|      92 %|      92 %|   2762515|   2760000|       113|         3|    4.923s|
|      93 %|      93 %|   2792651|   2790000|       250|         1|    4.977s|
|      94 %|      94 %|   2822639|   2820000|       183|        56|    4.957s|
|      95 %|      95 %|   2852670|   2850000|       169|       102|    4.937s|
|      96 %|      96 %|   2902400|   2880000|     10000|     10000|     6.81s|
|      97 %|      97 %|   2917955|   2910000|      5436|       147|    2.972s|
|      98 %|      98 %|   2944068|   2940000|      1581|        90|    4.701s|
|      99 %|      99 %|   2973289|   2970000|         0|       893|    4.989s|
|     100 %|     100 %|   3000001|   3000000|         0|         0|    4.911s|
PASS
ok  	github.com/larry618/eval	473.545s
```