### PR TITLE
[engine] update stack frame to store node index

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -368,7 +368,7 @@ func calculateNodeCosts(conf *CompileConfig, root *astNode) {
 
 	// base cost
 	switch nodeType {
-	case value:
+	case constant:
 		baseCost = inlinedCall
 	case selector:
 		baseCost = funcCall
@@ -444,7 +444,7 @@ func optimizeConstantFolding(cc *CompileConfig, root *astNode) error {
 
 	if isBoolOpNode(n) {
 		for _, child := range root.children {
-			if child.node.getNodeType() != value {
+			if child.node.getNodeType() != constant {
 				continue
 			}
 
@@ -455,7 +455,7 @@ func optimizeConstantFolding(cc *CompileConfig, root *astNode) error {
 
 			if (b && isOrOpNode(n)) || (!b && isAndOpNode(n)) {
 				root.node = &node{
-					flag:  value,
+					flag:  constant,
 					value: b,
 				}
 				root.children = nil
@@ -466,7 +466,7 @@ func optimizeConstantFolding(cc *CompileConfig, root *astNode) error {
 
 	params := make([]Value, len(root.children))
 	for i, child := range root.children {
-		if child.node.getNodeType() != value {
+		if child.node.getNodeType() != constant {
 			return nil
 		}
 		params[i] = child.node.value
@@ -478,7 +478,7 @@ func optimizeConstantFolding(cc *CompileConfig, root *astNode) error {
 	}
 	root.children = nil
 	root.node = &node{
-		flag:  value,
+		flag:  constant,
 		value: res,
 	}
 	return nil
@@ -517,7 +517,7 @@ func optimizeFastEvaluation(cc *CompileConfig, root *astNode) {
 
 	for _, child := range root.children {
 		typ := child.node.getNodeType()
-		if typ == value || typ == selector {
+		if typ == constant || typ == selector {
 			continue
 		}
 		return
@@ -584,7 +584,7 @@ func compress(root *astNode, size int) *Expr {
 		n.idx = int16(idx)
 		n.childCnt = int8(childCnt)
 		switch n.getNodeType() {
-		case value, selector:
+		case constant, selector:
 			n.childIdx = -1
 		default:
 			n.childIdx = int16(childIdx)

--- a/compile_test.go
+++ b/compile_test.go
@@ -140,7 +140,7 @@ func TestOptimizeConstantFolding(t *testing.T) {
 		{
 			expr: `(+ 1 1)`,
 			ast: verifyNode{
-				tpy:  value,
+				tpy:  constant,
 				data: int64(2),
 			},
 		},
@@ -148,7 +148,7 @@ func TestOptimizeConstantFolding(t *testing.T) {
 		{
 			expr: `(= 1 1)`,
 			ast: verifyNode{
-				tpy:  value,
+				tpy:  constant,
 				data: true,
 			},
 		},
@@ -162,7 +162,7 @@ func TestOptimizeConstantFolding(t *testing.T) {
 )
 `,
 			ast: verifyNode{
-				tpy:  value,
+				tpy:  constant,
 				data: int64(-204),
 			},
 		},
@@ -175,7 +175,7 @@ func TestOptimizeConstantFolding(t *testing.T) {
 )
 `,
 			ast: verifyNode{
-				tpy:  value,
+				tpy:  constant,
 				data: true,
 			},
 		},
@@ -199,20 +199,20 @@ func TestOptimizeConstantFolding(t *testing.T) {
 						tpy:  operator,
 						data: "+",
 						children: []verifyNode{
-							{tpy: value, data: int64(1)},
+							{tpy: constant, data: int64(1)},
 							{
 								tpy:  operator,
 								data: "-",
 								children: []verifyNode{
-									{tpy: value, data: int64(2)},
+									{tpy: constant, data: int64(2)},
 									{tpy: selector, data: "v3"},
 								},
 							},
-							{tpy: value, data: int64(2)},
-							{tpy: value, data: int64(4)},
+							{tpy: constant, data: int64(2)},
+							{tpy: constant, data: int64(4)},
 						},
 					},
-					{tpy: value, data: int64(210)},
+					{tpy: constant, data: int64(210)},
 				},
 			},
 		},
@@ -225,7 +225,7 @@ func TestOptimizeConstantFolding(t *testing.T) {
 )
 `,
 			ast: verifyNode{
-				tpy:  value,
+				tpy:  constant,
 				data: false,
 			},
 		},
@@ -253,7 +253,7 @@ func TestOptimizeConstantFolding(t *testing.T) {
 							{tpy: selector, data: "app_version"},
 						},
 					},
-					{tpy: value, data: int64(1_0002_0003)},
+					{tpy: constant, data: int64(1_0002_0003)},
 				},
 			},
 		},
@@ -276,7 +276,7 @@ func TestOptimizeConstantFolding(t *testing.T) {
 				},
 			},
 			ast: verifyNode{
-				tpy:  value,
+				tpy:  constant,
 				data: false,
 			},
 		},
@@ -299,7 +299,7 @@ func TestOptimizeConstantFolding(t *testing.T) {
 				},
 			},
 			ast: verifyNode{
-				tpy:  value,
+				tpy:  constant,
 				data: true,
 			},
 		},
@@ -343,8 +343,8 @@ func TestOptimizeConstantFolding(t *testing.T) {
 				tpy:  operator,
 				data: "is_child",
 				children: []verifyNode{
-					{tpy: value, data: "2022-02-02"},
-					{tpy: value, data: "2006-01-02"},
+					{tpy: constant, data: "2022-02-02"},
+					{tpy: constant, data: "2006-01-02"},
 				},
 			},
 		},
@@ -381,7 +381,7 @@ func TestOptimizeFastEvaluation(t *testing.T) {
 				tpy:  fastOperator,
 				data: "+",
 				children: []verifyNode{
-					{tpy: value, data: int64(1)},
+					{tpy: constant, data: int64(1)},
 					{tpy: selector, data: "v1"},
 				},
 			},
@@ -425,7 +425,7 @@ func TestOptimizeFastEvaluation(t *testing.T) {
 						tpy:  fastOperator,
 						data: "+",
 						children: []verifyNode{
-							{tpy: value, data: int64(1)},
+							{tpy: constant, data: int64(1)},
 							{tpy: selector, data: "v1"},
 						},
 					},
@@ -434,7 +434,7 @@ func TestOptimizeFastEvaluation(t *testing.T) {
 						data: "*",
 						children: []verifyNode{
 							{tpy: selector, data: "v2"},
-							{tpy: value, data: int64(3)},
+							{tpy: constant, data: int64(3)},
 							{tpy: selector, data: "v4"},
 						},
 					},
@@ -462,12 +462,12 @@ func TestOptimizeFastEvaluation(t *testing.T) {
 						tpy:  operator,
 						data: "+",
 						children: []verifyNode{
-							{tpy: value, data: int64(1)},
+							{tpy: constant, data: int64(1)},
 							{
 								tpy:  fastOperator,
 								data: "-",
 								children: []verifyNode{
-									{tpy: value, data: int64(2)},
+									{tpy: constant, data: int64(2)},
 									{tpy: selector, data: "v3"},
 								},
 							},
@@ -475,20 +475,20 @@ func TestOptimizeFastEvaluation(t *testing.T) {
 								tpy:  fastOperator,
 								data: "/",
 								children: []verifyNode{
-									{tpy: value, data: int64(6)},
-									{tpy: value, data: int64(3)},
+									{tpy: constant, data: int64(6)},
+									{tpy: constant, data: int64(3)},
 								},
 							},
-							{tpy: value, data: int64(4)},
+							{tpy: constant, data: int64(4)},
 						},
 					},
 					{
 						tpy:  fastOperator,
 						data: "*",
 						children: []verifyNode{
-							{tpy: value, data: int64(5)},
-							{tpy: value, data: int64(6)},
-							{tpy: value, data: int64(7)},
+							{tpy: constant, data: int64(5)},
+							{tpy: constant, data: int64(6)},
+							{tpy: constant, data: int64(7)},
 						},
 					},
 				},
@@ -540,7 +540,7 @@ func TestOptimizeFastEvaluation(t *testing.T) {
 				data: "is_child",
 				children: []verifyNode{
 					{tpy: selector, data: "birthday"},
-					{tpy: value, data: "Jan 02, 2006"}, // constant nodes will be replaced directly with the value
+					{tpy: constant, data: "Jan 02, 2006"}, // constant nodes will be replaced directly with the value
 				},
 			},
 		},
@@ -580,7 +580,7 @@ func TestReordering(t *testing.T) {
 				data: "+",
 				cost: 31, // 5(base) + 3(loops) + 10(op cost) + 13(children cost)
 				children: []verifyNode{
-					{tpy: value, data: int64(1), cost: 1},
+					{tpy: constant, data: int64(1), cost: 1},
 					{tpy: selector, data: "v1", cost: 12}, // 7 + 5
 				},
 			},
@@ -599,7 +599,7 @@ func TestReordering(t *testing.T) {
 				data: "+",
 				cost: 28, // 5(base) + 10(op cost) + 13(children cost)
 				children: []verifyNode{
-					{tpy: value, data: int64(1), cost: 1},
+					{tpy: constant, data: int64(1), cost: 1},
 					{tpy: selector, data: "v1", cost: 12}, // 7 + 5
 				},
 			},
@@ -682,7 +682,7 @@ func TestReordering(t *testing.T) {
 						cost: 34,
 						children: []verifyNode{
 							{tpy: selector, data: "v2", cost: 15},
-							{tpy: value, data: int64(2), cost: 1},
+							{tpy: constant, data: int64(2), cost: 1},
 						},
 					},
 					{
@@ -691,7 +691,7 @@ func TestReordering(t *testing.T) {
 						cost: 44,
 						children: []verifyNode{
 							{tpy: selector, data: "v1", cost: 25},
-							{tpy: value, data: int64(1), cost: 1},
+							{tpy: constant, data: int64(1), cost: 1},
 						},
 					},
 				},
@@ -726,13 +726,13 @@ func TestReordering(t *testing.T) {
 				data: "or",
 				cost: 138, // 5 + 4*1 + 3 + (1 + 16 + 109)
 				children: []verifyNode{
-					{tpy: value, data: false, cost: 1},
+					{tpy: constant, data: false, cost: 1},
 					{
 						tpy:  fastOperator,
 						data: "<",
 						cost: 16,
 						children: []verifyNode{
-							{tpy: value, data: int64(5), cost: 1},
+							{tpy: constant, data: int64(5), cost: 1},
 							{tpy: selector, data: "v6", cost: 7},
 						},
 					},
@@ -752,7 +752,7 @@ func TestReordering(t *testing.T) {
 										cost: 16, //  5 + 3 + (7 + 1)
 										children: []verifyNode{
 											{tpy: selector, data: "v6", cost: 7},
-											{tpy: value, data: int64(3), cost: 1},
+											{tpy: constant, data: int64(3), cost: 1},
 										},
 									},
 									{tpy: selector, data: "v4", cost: 7},
@@ -763,7 +763,7 @@ func TestReordering(t *testing.T) {
 								data: "=",
 								cost: 64, // 5 + 3 + (1 + 55)
 								children: []verifyNode{
-									{tpy: value, data: int64(3), cost: 1},
+									{tpy: constant, data: int64(3), cost: 1},
 									{tpy: selector, data: "v3", cost: 55},
 								},
 							},
@@ -812,7 +812,7 @@ func TestOptimize(t *testing.T) {
 				tpy:  fastOperator,
 				data: "+",
 				children: []verifyNode{
-					{tpy: value, data: int64(1)},
+					{tpy: constant, data: int64(1)},
 					{tpy: selector, data: "v1"},
 				},
 			},
@@ -821,7 +821,7 @@ func TestOptimize(t *testing.T) {
 		{
 			expr: `(= 1 1)`,
 			ast: verifyNode{
-				tpy:  value,
+				tpy:  constant,
 				data: true,
 			},
 		},
@@ -853,13 +853,13 @@ func TestOptimize(t *testing.T) {
 				data: "or",
 				cost: 120, // 5 + 4*1 + 3 + (1 + 16 + 91)
 				children: []verifyNode{
-					{tpy: value, data: false, cost: 1},
+					{tpy: constant, data: false, cost: 1},
 					{
 						tpy:  fastOperator,
 						data: "<",
 						cost: 16,
 						children: []verifyNode{
-							{tpy: value, data: int64(5), cost: 1},
+							{tpy: constant, data: int64(5), cost: 1},
 							{tpy: selector, data: "v6", cost: 7},
 						},
 					},
@@ -873,7 +873,7 @@ func TestOptimize(t *testing.T) {
 								data: "<",
 								cost: 16, // 5 + 3 + (1 + 7)
 								children: []verifyNode{
-									{tpy: value, data: int64(2), cost: 1},
+									{tpy: constant, data: int64(2), cost: 1},
 									{tpy: selector, data: "v4", cost: 7},
 								},
 							},
@@ -882,7 +882,7 @@ func TestOptimize(t *testing.T) {
 								data: "=",
 								cost: 64, // 5 + 3 + (1 + 55)
 								children: []verifyNode{
-									{tpy: value, data: int64(3), cost: 1},
+									{tpy: constant, data: int64(3), cost: 1},
 									{tpy: selector, data: "v3", cost: 55},
 								},
 							},
@@ -937,7 +937,7 @@ func TestOptimize(t *testing.T) {
 				data: "is_child",
 				children: []verifyNode{
 					{tpy: selector, data: "birthday"},
-					{tpy: value, data: "Jan 02, 2006"}, // constant nodes will be replaced directly with the value
+					{tpy: constant, data: "Jan 02, 2006"}, // constant nodes will be replaced directly with the value
 				},
 			},
 		},

--- a/engine.go
+++ b/engine.go
@@ -31,7 +31,7 @@ const (
 type node struct {
 	flag     uint8
 	childCnt int8
-	idx      int16
+	scIdx    int16
 	childIdx int16
 	selKey   SelectorKey
 	value    Value
@@ -247,15 +247,15 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 					printShortCircuit(curt)
 				}
 
-				scIdx := e.scIdx[curt.idx]
-				if scIdx == 0 {
+				curtIdx = int(curt.scIdx)
+				if curtIdx == 0 {
 					return res, nil
 				}
 
-				maxIdx = scIdx
-				sfTop = e.sfSize[scIdx] - 2
-				osTop = e.osSize[scIdx] - 1
-				curt = e.nodes[scIdx]
+				maxIdx = curtIdx
+				sfTop = e.sfSize[curtIdx] - 2
+				osTop = e.osSize[curtIdx] - 1
+				curt = e.nodes[curtIdx]
 			}
 		}
 

--- a/engine.go
+++ b/engine.go
@@ -16,7 +16,7 @@ type (
 const (
 	// node types
 	nodeTypeMask = uint8(0b111)
-	value        = uint8(0b001)
+	constant     = uint8(0b001)
 	selector     = uint8(0b010)
 	operator     = uint8(0b011)
 	fastOperator = uint8(0b100)
@@ -129,7 +129,7 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 
 	for sfTop != -1 { // while stack frame is not empty
 		if debug {
-			//printStacks(maxIdx, os, osTop, sf, sfTop)
+			printStacks(e, maxIdx, os, osTop, sf, sfTop)
 		}
 		curtIdx, sfTop = sf[sfTop], sfTop-1
 		curt = e.nodes[curtIdx]
@@ -209,7 +209,7 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 			if err != nil {
 				return nil, err
 			}
-		case value:
+		case constant:
 			res = curt.value
 		case cond:
 			childIdx := int(curt.childIdx)
@@ -304,7 +304,7 @@ func unifyType(val Value) Value {
 }
 
 func getNodeValue(ctx *Ctx, n *node) (res Value, err error) {
-	if n.flag&nodeTypeMask == value {
+	if n.flag&nodeTypeMask == constant {
 		res = n.value
 	} else {
 		res, err = getSelectorValue(ctx, n)
@@ -326,13 +326,13 @@ func getSelectorValue(ctx *Ctx, n *node) (Value, error) {
 	}
 }
 
-func printStacks(maxId int, os []Value, osTop int, sf []*node, sfTop int) {
+func printStacks(e *Expr, maxId int, os []Value, osTop int, sf []int, sfTop int) {
 	var sb strings.Builder
 
 	fmt.Printf("maxId:%d, sfTop:%d, osTop:%d\n", maxId, sfTop, osTop)
 	sb.WriteString(fmt.Sprintf("%15s", "Stack Frame: "))
 	for i := sfTop; i >= 0; i-- {
-		sb.WriteString(fmt.Sprintf("|%4v", sf[i].value))
+		sb.WriteString(fmt.Sprintf("|%4v", e.nodes[sf[i]].value))
 	}
 	sb.WriteString("|\n")
 

--- a/engine.go
+++ b/engine.go
@@ -87,6 +87,7 @@ func (e *Expr) EvalBool(ctx *Ctx) (bool, error) {
 func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 	var (
 		size   = e.maxStackSize
+		nodes  = e.nodes
 		debug  = ctx.Debug
 		maxIdx = -1
 
@@ -132,18 +133,18 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 			printStacks(e, maxIdx, os, osTop, sf, sfTop)
 		}
 		curtIdx, sfTop = sf[sfTop], sfTop-1
-		curt = e.nodes[curtIdx]
+		curt = nodes[curtIdx]
 
 		switch curt.flag & nodeTypeMask {
 		case fastOperator:
 			cnt := int(curt.childCnt)
 			childIdx := int(curt.childIdx)
 			if cnt == 2 {
-				param2[0], err = getNodeValue(ctx, e.nodes[childIdx])
+				param2[0], err = getNodeValue(ctx, nodes[childIdx])
 				if err != nil {
 					return nil, err
 				}
-				param2[1], err = getNodeValue(ctx, e.nodes[childIdx+1])
+				param2[1], err = getNodeValue(ctx, nodes[childIdx+1])
 				if err != nil {
 					return nil, err
 				}
@@ -151,7 +152,7 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 			} else {
 				param = make([]Value, cnt)
 				for i := 0; i < cnt; i++ {
-					child := e.nodes[childIdx+i]
+					child := nodes[childIdx+i]
 					param[i], err = getNodeValue(ctx, child)
 					if err != nil {
 						return nil, err
@@ -255,7 +256,7 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 				maxIdx = curtIdx
 				sfTop = e.sfSize[curtIdx] - 2
 				osTop = e.osSize[curtIdx] - 1
-				curt = e.nodes[curtIdx]
+				curt = nodes[curtIdx]
 			}
 		}
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDebugCases(t *testing.T) {
-	const onlyAllowListCases = true
+	const onlyAllowListCases = false
 
 	type runThis string
 	const ________RunThisOne________ runThis = "________RunThisOne________"

--- a/parse.go
+++ b/parse.go
@@ -347,7 +347,7 @@ func (p *parser) pos(i int) string {
 func (p *parser) valNode(v Value) *astNode {
 	return &astNode{
 		node: &node{
-			flag:  value,
+			flag:  constant,
 			value: v,
 		},
 	}
@@ -377,7 +377,7 @@ func (p *parser) parseList() (*astNode, error) {
 
 	// todo: return error when list is empty
 
-	n := &node{flag: value}
+	n := &node{flag: constant}
 	if typ == integer {
 		ints := make([]int64, 0, len(strs))
 		for _, s := range strs {

--- a/parse_test.go
+++ b/parse_test.go
@@ -575,8 +575,8 @@ func TestParseAstTree(t *testing.T) {
 				tpy:  operator,
 				data: "+",
 				children: []verifyNode{
-					{tpy: value, data: int64(1)},
-					{tpy: value, data: int64(1)},
+					{tpy: constant, data: int64(1)},
+					{tpy: constant, data: int64(1)},
 				},
 			},
 		},
@@ -600,12 +600,12 @@ func TestParseAstTree(t *testing.T) {
 						tpy:  operator,
 						data: "+",
 						children: []verifyNode{
-							{tpy: value, data: int64(1)},
+							{tpy: constant, data: int64(1)},
 							{
 								tpy:  operator,
 								data: "-",
 								children: []verifyNode{
-									{tpy: value, data: int64(2)},
+									{tpy: constant, data: int64(2)},
 									{tpy: selector, data: "v3", selectKey: SelectorKey(3)},
 								},
 							},
@@ -613,20 +613,20 @@ func TestParseAstTree(t *testing.T) {
 								tpy:  operator,
 								data: "/",
 								children: []verifyNode{
-									{tpy: value, data: int64(-6)},
-									{tpy: value, data: int64(3)},
+									{tpy: constant, data: int64(-6)},
+									{tpy: constant, data: int64(3)},
 								},
 							},
-							{tpy: value, data: int64(4)},
+							{tpy: constant, data: int64(4)},
 						},
 					},
 					{
 						tpy:  operator,
 						data: "*",
 						children: []verifyNode{
-							{tpy: value, data: int64(5)},
-							{tpy: value, data: int64(6)},
-							{tpy: value, data: int64(7)},
+							{tpy: constant, data: int64(5)},
+							{tpy: constant, data: int64(6)},
+							{tpy: constant, data: int64(7)},
 						},
 					},
 				},
@@ -661,10 +661,10 @@ func TestParseAstTree(t *testing.T) {
 						data: "<=",
 						children: []verifyNode{
 							{tpy: selector, data: "age", selectKey: SelectorKey(1)},
-							{tpy: value, data: int64(3)},
+							{tpy: constant, data: int64(3)},
 						},
 					},
-					{tpy: value, data: "👋~ 👶"},
+					{tpy: constant, data: "👋~ 👶"},
 					{
 						tpy:  cond,
 						data: "if",
@@ -678,7 +678,7 @@ func TestParseAstTree(t *testing.T) {
 										data: "in",
 										children: []verifyNode{
 											{tpy: selector, data: "language", selectKey: SelectorKey(2)},
-											{tpy: value, data: []string{"zh", "zh-CN"}},
+											{tpy: constant, data: []string{"zh", "zh-CN"}},
 										},
 									},
 									{
@@ -686,13 +686,13 @@ func TestParseAstTree(t *testing.T) {
 										data: "=",
 										children: []verifyNode{
 											{tpy: selector, data: "country", selectKey: SelectorKey(3)},
-											{tpy: value, data: "CN"},
+											{tpy: constant, data: "CN"},
 										},
 									},
 								},
 							},
-							{tpy: value, data: "你好"},
-							{tpy: value, data: "hello"},
+							{tpy: constant, data: "你好"},
+							{tpy: constant, data: "hello"},
 							{tpy: end, data: "end"},
 						},
 					},
@@ -745,7 +745,7 @@ func TestParseAstTree(t *testing.T) {
 				data: "is_child",
 				children: []verifyNode{
 					{tpy: selector, data: "birthday", selectKey: SelectorKey(3)},
-					{tpy: value, data: "Jan 02, 2006"}, // constant nodes will be replaced directly with the value
+					{tpy: constant, data: "Jan 02, 2006"}, // constant nodes will be replaced directly with the value
 				},
 			},
 		},
@@ -766,14 +766,14 @@ func TestParseAstTree(t *testing.T) {
 		{
 			expr: `()`,
 			ast: verifyNode{
-				tpy:  value,
+				tpy:  constant,
 				data: []string{},
 			},
 		},
 		{
 			expr: `(1)`,
 			ast: verifyNode{
-				tpy:  value,
+				tpy:  constant,
 				data: []int64{1},
 			},
 		},
@@ -783,8 +783,8 @@ func TestParseAstTree(t *testing.T) {
 				tpy:  operator,
 				data: "overlap",
 				children: []verifyNode{
-					{tpy: value, data: []string{}},
-					{tpy: value, data: []int64{1, 2, 4}},
+					{tpy: constant, data: []string{}},
+					{tpy: constant, data: []int64{1, 2, 4}},
 				},
 			},
 		},
@@ -794,8 +794,8 @@ func TestParseAstTree(t *testing.T) {
 				tpy:  operator,
 				data: "in",
 				children: []verifyNode{
-					{tpy: value, data: ""},
-					{tpy: value, data: []string{}},
+					{tpy: constant, data: ""},
+					{tpy: constant, data: []string{}},
 				},
 			},
 		},
@@ -813,7 +813,7 @@ func TestParseAstTree(t *testing.T) {
 				data: "<",
 				children: []verifyNode{
 					{tpy: selector, data: "age"},
-					{tpy: value, data: int64(18)},
+					{tpy: constant, data: int64(18)},
 				},
 			},
 		},

--- a/util.go
+++ b/util.go
@@ -483,7 +483,7 @@ func PrintExpr(expr *Expr, fields ...string) string {
 				res = "OPf"
 			case selector:
 				res = "S"
-			case value:
+			case constant:
 				res = "V"
 			case cond:
 				res = "IF"


### PR DESCRIPTION
## Summary
This PR updates stack frame of eval engine to store node index instead of node reference. This update brings a small performance boost.

```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/larry618/eval_bench
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16     	40322376	        82.82 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16      	40452094	        87.58 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16    	42909973	        83.44 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16     	40189705	        87.79 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/larry618/eval_bench	14.918s
```

## Test Plan
- [X] Unit test passed
```
❯ go test
PASS
ok  	github.com/larry618/eval	1.783s
```

- [X] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/larry618/eval_bench
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16     	39299862	        83.81 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16      	39290820	        88.17 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16    	41984768	        83.71 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16     	39759696	        88.71 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/larry618/eval_bench	14.608s
```

- [x] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     38308|     30000|      5889|        19|    2.528s|
|       2 %|       2 %|     65267|     60000|      2660|       207|    3.908s|
|       3 %|       3 %|     93217|     90000|       717|       100|    4.582s|
|       4 %|       4 %|    122629|    120000|        84|       145|    4.241s|
|       5 %|       5 %|    153569|    150000|      1119|        50|    4.598s|
|       6 %|       6 %|    183003|    180000|       395|       208|    4.499s|
|       7 %|       7 %|    212460|    210000|        48|        12|    4.849s|
|       8 %|       8 %|    243191|    240000|       663|       128|    5.365s|
|       9 %|       9 %|    272829|    270000|       332|        97|    4.904s|
|      10 %|      10 %|    302672|    300000|        70|       202|    5.059s|
|      11 %|      11 %|    333997|    330000|      1591|         6|    4.995s|
|      12 %|      12 %|    363458|    360000|      1046|        12|    4.613s|
|      13 %|      13 %|    392651|    390000|       141|       110|    5.113s|
|      14 %|      14 %|    422437|    420000|        15|        22|    4.941s|
|      15 %|      15 %|    453040|    450000|       489|       151|    4.982s|
|      16 %|      16 %|    482550|    480000|       105|        45|    4.751s|
|      17 %|      17 %|    512694|    510000|       240|        54|    5.245s|
|      18 %|      18 %|    542767|    540000|       345|        22|    4.679s|
|      19 %|      19 %|    573013|    570000|       472|       141|    5.046s|
|      20 %|      20 %|    602475|    600000|        27|        48|    5.066s|
|      21 %|      21 %|    632547|    630000|        56|        91|    5.343s|
|      22 %|      22 %|    663294|    660000|       804|        90|     5.21s|
|      23 %|      23 %|    692838|    690000|       234|       204|    5.198s|
|      24 %|      24 %|    722741|    720000|       247|        94|    5.284s|
|      25 %|      25 %|    752948|    750000|       529|        19|    5.454s|
|      26 %|      26 %|    783077|    780000|       570|       107|    5.427s|
|      27 %|      27 %|    812478|    810000|        50|        28|    5.061s|
|      28 %|      28 %|    843479|    840000|       991|        88|    5.126s|
|      29 %|      29 %|    874003|    870000|       406|      1197|    5.301s|
|      30 %|      30 %|    903677|    900000|      1236|        41|    4.912s|
|      31 %|      31 %|    932526|    930000|       116|        10|    5.356s|
|      32 %|      32 %|    962420|    960000|         0|        24|    4.882s|
|      33 %|      33 %|    992436|    990000|        11|        25|    5.294s|
|      34 %|      34 %|   1028725|   1020000|      6294|        32|    5.171s|
|      35 %|      35 %|   1052470|   1050000|        34|        36|    4.989s|
|      36 %|      36 %|   1082946|   1080000|       435|       111|    5.292s|
|      37 %|      37 %|   1112399|   1110000|         0|         2|    5.159s|
|      38 %|      38 %|   1142935|   1140000|       504|        31|     5.23s|
|      39 %|      39 %|   1173384|   1170000|       897|        87|    5.477s|
|      40 %|      40 %|   1202618|   1200000|       179|        39|    5.536s|
|      41 %|      41 %|   1232439|   1230000|        15|        24|    5.256s|
|      42 %|      42 %|   1262399|   1260000|         0|        13|     5.22s|
|      43 %|      43 %|   1292504|   1290000|        15|        89|     5.08s|
|      44 %|      44 %|   1322390|   1320000|         0|         0|    5.175s|
|      45 %|      45 %|   1352651|   1350000|        97|       154|    5.307s|
|      46 %|      46 %|   1382378|   1380000|         0|         0|    5.485s|
|      47 %|      47 %|   1412382|   1410000|         0|         0|    5.478s|
|      48 %|      48 %|   1442751|   1440000|       304|        47|    5.348s|
|      49 %|      49 %|   1472769|   1470000|       204|       165|    5.305s|
|      50 %|      50 %|   1502681|   1500000|       246|        35|    5.304s|
|      51 %|      51 %|   1532488|   1530000|        28|        60|    5.428s|
|      52 %|      52 %|   1564494|   1560000|      2024|        70|    5.795s|
|      53 %|      53 %|   1592965|   1590000|       507|        58|    5.608s|
|      54 %|      54 %|   1642400|   1620000|     10000|     10000|    7.857s|
|      55 %|      55 %|   1657193|   1650000|      4792|         1|    3.483s|
|      56 %|      56 %|   1682525|   1680000|       121|         4|    5.661s|
|      57 %|      57 %|   1713626|   1710000|         2|      1224|    5.861s|
|      58 %|      58 %|   1744080|   1740000|      1672|         8|    5.159s|
|      59 %|      59 %|   1773833|   1770000|      1380|        53|    5.527s|
|      60 %|      60 %|   1802739|   1800000|       319|        21|    5.467s|
|      61 %|      61 %|   1838529|   1830000|      6055|        75|    5.572s|
|      62 %|      62 %|   1862578|   1860000|         1|       177|    5.178s|
|      63 %|      63 %|   1892397|   1890000|         0|         8|    5.358s|
|      64 %|      64 %|   1922413|   1920000|         0|        37|    5.458s|
|      65 %|      65 %|   1952727|   1950000|       327|         0|     5.56s|
|      66 %|      66 %|   1982617|   1980000|       177|        40|    5.878s|
|      67 %|      67 %|   2012971|   2010000|       427|       144|    5.476s|
|      68 %|      68 %|   2043407|   2040000|       904|       103|    5.687s|
|      69 %|      69 %|   2072399|   2070000|         0|         1|    5.567s|
|      70 %|      70 %|   2102614|   2100000|       151|        63|    5.871s|
|      71 %|      71 %|   2132560|   2130000|         4|       156|    5.993s|
|      72 %|      72 %|   2182400|   2160000|     10000|     10000|    8.266s|
|      73 %|      73 %|   2201336|   2190000|      8893|        43|     3.52s|
|      74 %|      74 %|   2232352|   2220000|      9925|        27|     5.87s|
|      75 %|      75 %|   2257901|   2250000|      5467|        34|    5.393s|
|      76 %|      76 %|   2282969|   2280000|       436|       133|    5.263s|
|      77 %|      77 %|   2312619|   2310000|       166|        53|    5.627s|
|      78 %|      78 %|   2342504|   2340000|        51|        53|    5.653s|
|      79 %|      79 %|   2372537|   2370000|       131|         6|    5.366s|
|      80 %|      80 %|   2402851|   2400000|       364|        87|    5.473s|
|      81 %|      81 %|   2432694|   2430000|       193|       101|    5.431s|
|      82 %|      82 %|   2463011|   2460000|       583|        28|    5.307s|
|      83 %|      83 %|   2492653|   2490000|       119|       134|    5.464s|
|      84 %|      84 %|   2522517|   2520000|       110|         7|    5.283s|
|      85 %|      85 %|   2552786|   2550000|       361|        25|    5.528s|
|      86 %|      86 %|   2582558|   2580000|        74|        84|    5.375s|
|      87 %|      87 %|   2612838|   2610000|       396|        42|    5.351s|
|      88 %|      88 %|   2642608|   2640000|       146|        62|    5.406s|
|      89 %|      89 %|   2672978|   2670000|       569|         9|    5.516s|
|      90 %|      90 %|   2702664|   2700000|       222|        42|    5.467s|
|      91 %|      91 %|   2733474|   2730000|       988|        86|    5.273s|
|      92 %|      92 %|   2762473|   2760000|        15|        58|    5.366s|
|      93 %|      93 %|   2793067|   2790000|       289|       378|    5.437s|
|      94 %|      94 %|   2822393|   2820000|         0|         0|    5.265s|
|      95 %|      95 %|   2852597|   2850000|       113|        84|    5.357s|
|      96 %|      96 %|   2882404|   2880000|         0|         9|    5.384s|
|      97 %|      97 %|   2912560|   2910000|         0|       165|    5.403s|
|      98 %|      98 %|   2943181|   2940000|       732|        49|    5.352s|
|      99 %|      99 %|   2972445|   2970000|        21|        24|    5.399s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|    5.567s|
PASS
ok  	github.com/larry618/eval	529.520s
```

## Reviewers
@larry618