### PR TITLE
[engine] [compile] add debug node type

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -168,7 +168,7 @@ func setDebugInfo(e *Expr) {
 		parentIdx := e.parentIdx[i]
 
 		debugNode := &node{
-			flag:     realNode.flag | debug,
+			flag:     debug,
 			value:    realNode.value,
 			childIdx: realNode.childIdx,
 			childCnt: realNode.childCnt,

--- a/compile.go
+++ b/compile.go
@@ -6,16 +6,16 @@ import (
 	"sort"
 )
 
-type OptimizeOption string
+type CompileOption string
 
 const (
-	AllOptimizations OptimizeOption = "optimize"
-	Reordering       OptimizeOption = "reordering"
-	FastEvaluation   OptimizeOption = "fast_evaluation"
-	ConstantFolding  OptimizeOption = "constant_folding"
+	AllOptimizations CompileOption = "optimize"
+	Reordering       CompileOption = "reordering"
+	FastEvaluation   CompileOption = "fast_evaluation"
+	ConstantFolding  CompileOption = "constant_folding"
 
-	Debug                 OptimizeOption = "debug"
-	AllowUnknownSelectors OptimizeOption = "allow_unknown_selectors"
+	Debug                 CompileOption = "debug"
+	AllowUnknownSelectors CompileOption = "allow_unknown_selectors"
 )
 
 func CopyCompileConfig(origin *CompileConfig) *CompileConfig {
@@ -32,8 +32,8 @@ func CopyCompileConfig(origin *CompileConfig) *CompileConfig {
 	for k, v := range origin.OperatorMap {
 		conf.OperatorMap[k] = v
 	}
-	for k, v := range origin.OptimizeOptions {
-		conf.OptimizeOptions[k] = v
+	for k, v := range origin.CompileOptions {
+		conf.CompileOptions[k] = v
 	}
 	for k, v := range origin.CostsMap {
 		conf.CostsMap[k] = v
@@ -44,11 +44,11 @@ func CopyCompileConfig(origin *CompileConfig) *CompileConfig {
 
 func NewCompileConfig() *CompileConfig {
 	return &CompileConfig{
-		ConstantMap:     make(map[string]Value),
-		SelectorMap:     make(map[string]SelectorKey),
-		OperatorMap:     make(map[string]Operator),
-		OptimizeOptions: make(map[OptimizeOption]bool),
-		CostsMap:        make(map[string]int),
+		ConstantMap:    make(map[string]Value),
+		SelectorMap:    make(map[string]SelectorKey),
+		OperatorMap:    make(map[string]Operator),
+		CompileOptions: make(map[CompileOption]bool),
+		CostsMap:       make(map[string]int),
 
 		AllowUnknownSelectors: false,
 	}
@@ -63,7 +63,7 @@ type CompileConfig struct {
 	CostsMap map[string]int
 
 	// compile options
-	OptimizeOptions map[OptimizeOption]bool
+	CompileOptions map[CompileOption]bool
 
 	AllowUnknownSelectors bool
 }
@@ -117,7 +117,7 @@ func Compile(originConf *CompileConfig, exprStr string) (*Expr, error) {
 
 	setExtraInfo(expr)
 
-	if conf.OptimizeOptions[Debug] {
+	if conf.CompileOptions[Debug] {
 		setDebugInfo(expr)
 	}
 	return expr, nil
@@ -354,15 +354,15 @@ func calAndSetShortCircuit(e *Expr) {
 }
 
 func optimize(cc *CompileConfig, root *astNode) {
-	if enabled, exist := cc.OptimizeOptions[ConstantFolding]; enabled || !exist {
+	if enabled, exist := cc.CompileOptions[ConstantFolding]; enabled || !exist {
 		_ = optimizeConstantFolding(cc, root)
 	}
 
-	if enabled, exist := cc.OptimizeOptions[FastEvaluation]; enabled || !exist {
+	if enabled, exist := cc.CompileOptions[FastEvaluation]; enabled || !exist {
 		optimizeFastEvaluation(cc, root)
 	}
 
-	if enabled, exist := cc.OptimizeOptions[Reordering]; enabled || !exist {
+	if enabled, exist := cc.CompileOptions[Reordering]; enabled || !exist {
 		calculateNodeCosts(cc, root)
 		optimizeReordering(root)
 	}

--- a/compile.go
+++ b/compile.go
@@ -9,14 +9,16 @@ import (
 type Option string
 
 const (
-	AllOptimizations Option = "optimize"
-	Reordering       Option = "reordering"
-	FastEvaluation   Option = "fast_evaluation"
-	ConstantFolding  Option = "constant_folding"
+	Optimize        Option = "optimize" // switch all optimizations
+	Reordering      Option = "reordering"
+	FastEvaluation  Option = "fast_evaluation"
+	ConstantFolding Option = "constant_folding"
 
 	Debug                 Option = "debug"
 	AllowUnknownSelectors Option = "allow_unknown_selectors"
 )
+
+var AllOptimizations = []Option{Reordering, FastEvaluation, ConstantFolding}
 
 func CopyCompileConfig(origin *CompileConfig) *CompileConfig {
 	conf := NewCompileConfig()
@@ -50,10 +52,15 @@ var (
 	EnableDebug CompileOption = func(c *CompileConfig) {
 		c.CompileOptions[Debug] = true
 	}
-	DisableAllOptimizations CompileOption = func(c *CompileConfig) {
-		c.CompileOptions[Reordering] = false
-		c.CompileOptions[FastEvaluation] = false
-		c.CompileOptions[ConstantFolding] = false
+	Optimizations = func(enable bool, opts ...Option) CompileOption {
+		return func(c *CompileConfig) {
+			if len(opts) == 0 || opts[0] == Optimize {
+				opts = AllOptimizations
+			}
+			for _, opt := range opts {
+				c.CompileOptions[opt] = enable
+			}
+		}
 	}
 )
 

--- a/compile_test.go
+++ b/compile_test.go
@@ -15,14 +15,14 @@ func TestCopyCompileConfig(t *testing.T) {
 	assertNotNil(t, res.OperatorMap)
 	assertNotNil(t, res.ConstantMap)
 	assertNotNil(t, res.SelectorMap)
-	assertNotNil(t, res.OptimizeOptions)
+	assertNotNil(t, res.CompileOptions)
 
 	res = CopyCompileConfig(&CompileConfig{})
 	assertNotNil(t, res)
 	assertNotNil(t, res.OperatorMap)
 	assertNotNil(t, res.ConstantMap)
 	assertNotNil(t, res.SelectorMap)
-	assertNotNil(t, res.OptimizeOptions)
+	assertNotNil(t, res.CompileOptions)
 
 	cc := &CompileConfig{
 		ConstantMap: map[string]Value{
@@ -64,7 +64,7 @@ func TestCopyCompileConfig(t *testing.T) {
 			"selectors": 10,
 			"operators": 20,
 		},
-		OptimizeOptions: map[OptimizeOption]bool{
+		CompileOptions: map[CompileOption]bool{
 			Reordering:      true,
 			ConstantFolding: false,
 		},
@@ -73,7 +73,7 @@ func TestCopyCompileConfig(t *testing.T) {
 	res = CopyCompileConfig(cc)
 	assertEquals(t, res.ConstantMap, cc.ConstantMap)
 	assertEquals(t, res.SelectorMap, cc.SelectorMap)
-	assertEquals(t, res.OptimizeOptions, cc.OptimizeOptions)
+	assertEquals(t, res.CompileOptions, cc.CompileOptions)
 	assertEquals(t, res.CostsMap, cc.CostsMap)
 
 	assertEquals(t, len(res.OperatorMap), len(cc.OperatorMap))

--- a/compile_test.go
+++ b/compile_test.go
@@ -64,7 +64,7 @@ func TestCopyCompileConfig(t *testing.T) {
 			"selectors": 10,
 			"operators": 20,
 		},
-		CompileOptions: map[CompileOption]bool{
+		CompileOptions: map[Option]bool{
 			Reordering:      true,
 			ConstantFolding: false,
 		},

--- a/engine.go
+++ b/engine.go
@@ -15,8 +15,7 @@ type (
 
 type Ctx struct {
 	Selector
-	Ctx   context.Context
-	Debug bool
+	Ctx context.Context
 }
 
 const (
@@ -316,8 +315,8 @@ func getNodeValue(ctx *Ctx, n *node) (res Value, err error) {
 	return
 }
 
-func getSelectorValue(ctx *Ctx, n *node) (Value, error) {
-	res, err := ctx.Get(n.selKey, n.value.(string))
+func getSelectorValue(ctx *Ctx, n *node) (res Value, err error) {
+	res, err = ctx.Get(n.selKey, n.value.(string))
 	if err != nil {
 		return nil, err
 	}

--- a/engine.go
+++ b/engine.go
@@ -237,12 +237,13 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 		case end:
 			maxIdx = e.parentIdx[curtIdx]
 			res, osTop = os[osTop], osTop-1
-		default: // only debug node will enter this branch
-			l := len(e.nodes) / 2
-			replaceWithDebugNode(sf, sfTop, l)
+		default:
+			// only debug node will enter this branch
+			offset := len(e.nodes) / 2
+			debugStackFrame(sf, sfTop, offset)
 
 			// push the real node to print stacks
-			sf[sfTop+1], sfTop = curtIdx+l, sfTop+1
+			sf[sfTop+1], sfTop = curtIdx+offset, sfTop+1
 
 			e.printStacks(scTriggered, os, osTop, sf, sfTop)
 			scTriggered = false
@@ -272,15 +273,6 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 		os[osTop+1], osTop = res, osTop+1
 	}
 	return os[0], nil
-}
-
-func replaceWithDebugNode(sf []int, sfTop, boundary int) {
-	// replace with debug node
-	for i := 0; i < sfTop; i++ {
-		if sf[i] >= boundary {
-			sf[i] -= boundary
-		}
-	}
 }
 
 func unifyType(val Value) Value {
@@ -338,9 +330,18 @@ func getSelectorValue(ctx *Ctx, n *node) (Value, error) {
 	}
 }
 
+func debugStackFrame(sf []int, sfTop, offset int) {
+	// replace with debug node
+	for i := 0; i < sfTop; i++ {
+		if sf[i] >= offset {
+			sf[i] -= offset
+		}
+	}
+}
+
 func (e *Expr) printStacks(scTriggered bool, os []Value, osTop int, sf []int, sfTop int) {
 	if scTriggered {
-		fmt.Println("short circuit triggered")
+		fmt.Printf("short circuit triggered\n\n")
 	}
 
 	var sb strings.Builder

--- a/engine.go
+++ b/engine.go
@@ -245,7 +245,7 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 			// push the real node to print stacks
 			sf[sfTop+1], sfTop = curtIdx+offset, sfTop+1
 
-			e.printStacks(scTriggered, os, osTop, sf, sfTop)
+			e.printStacks(scTriggered, maxIdx, os, osTop, sf, sfTop)
 			scTriggered = false
 			continue
 		}
@@ -339,14 +339,15 @@ func debugStackFrame(sf []int, sfTop, offset int) {
 	}
 }
 
-func (e *Expr) printStacks(scTriggered bool, os []Value, osTop int, sf []int, sfTop int) {
+func (e *Expr) printStacks(scTriggered bool, maxIdx int, os []Value, osTop int, sf []int, sfTop int) {
 	if scTriggered {
 		fmt.Printf("short circuit triggered\n\n")
 	}
-
 	var sb strings.Builder
 
-	fmt.Printf("sfTop:%d, osTop:%d\n", sfTop, osTop)
+	offset := len(e.nodes) / 2
+
+	fmt.Printf("maxIdx:%d, sfTop:%d, osTop:%d\n", maxIdx-offset, sfTop, osTop)
 	sb.WriteString(fmt.Sprintf("%15s", "Stack Frame: "))
 	for i := sfTop; i >= 0; i-- {
 		sb.WriteString(fmt.Sprintf("|%4v", e.nodes[sf[i]].value))

--- a/engine_test.go
+++ b/engine_test.go
@@ -13,16 +13,16 @@ import (
 )
 
 func TestDebug(t *testing.T) {
-	//	s := `
-	//(or
-	//  (and
-	//    (= 1 1)
-	//    (< 4 2)
-	//    (!= 5 6))
-	//  (eq 8 -8))
-	//`
+	s := `
+	(or
+	 (and
+	   (= 1 1)
+	   (< 4 2)
+	   (!= 5 6))
+	 (eq 8 -8))
+	`
 
-	s := `(+ 1 2)`
+	//s := `(+ 1 2)`
 	expr, err := Compile(&CompileConfig{
 		OptimizeOptions: map[OptimizeOption]bool{
 			ConstantFolding: false,

--- a/engine_test.go
+++ b/engine_test.go
@@ -13,14 +13,16 @@ import (
 )
 
 func TestDebug(t *testing.T) {
-	s := `
-(or
-  (if
-    (= 1 1)
-    (< 4 2)
-    (!= 5 6))
-  (eq 8 -8))
-`
+	//	s := `
+	//(or
+	//  (and
+	//    (= 1 1)
+	//    (< 4 2)
+	//    (!= 5 6))
+	//  (eq 8 -8))
+	//`
+
+	s := `(+ 1 2)`
 	expr, err := Compile(&CompileConfig{
 		OptimizeOptions: map[OptimizeOption]bool{
 			ConstantFolding: false,

--- a/engine_test.go
+++ b/engine_test.go
@@ -12,6 +12,34 @@ import (
 	"time"
 )
 
+func TestDebug(t *testing.T) {
+	s := `
+(or
+  (if
+    (= 1 1)
+    (< 4 2)
+    (!= 5 6))
+  (eq 8 -8))
+`
+	expr, err := Compile(&CompileConfig{
+		OptimizeOptions: map[OptimizeOption]bool{
+			ConstantFolding: false,
+			FastEvaluation:  false,
+			Reordering:      false,
+			Debug:           true,
+		},
+	}, s)
+
+	assertNil(t, err)
+
+	fmt.Println(PrintExpr(expr))
+
+	res, err := expr.Eval(&Ctx{Debug: false})
+
+	assertNil(t, err)
+	fmt.Println(res)
+}
+
 func TestDebugCases(t *testing.T) {
 	const onlyAllowListCases = false
 
@@ -461,7 +489,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 3000000
+		size          = 10000
 		level         = 53
 		step          = size / 100
 		showSample    = false

--- a/engine_test.go
+++ b/engine_test.go
@@ -16,7 +16,8 @@ func TestDebug(t *testing.T) {
 	s := `
 	(not
 	(and
-	 (if T
+	 (if 
+       (< 2 3)
 	   (!= 0 0)
 	   (= 0 0))
 	 (= 0 0)
@@ -24,14 +25,8 @@ func TestDebug(t *testing.T) {
 	`
 
 	//s := `(+ 1 2)`
-	expr, err := Compile(&CompileConfig{
-		CompileOptions: map[CompileOption]bool{
-			ConstantFolding: false,
-			FastEvaluation:  false,
-			Reordering:      false,
-			Debug:           true,
-		},
-	}, s)
+	conf := NewCompileConfig(EnableDebug, DisableAllOptimizations)
+	expr, err := Compile(conf, s)
 
 	assertNil(t, err)
 
@@ -392,7 +387,7 @@ func TestDebugCases(t *testing.T) {
 		}
 
 		cc := NewCompileConfig()
-		cc.CompileOptions = map[CompileOption]bool{
+		cc.CompileOptions = map[Option]bool{
 			Reordering:      false,
 			FastEvaluation:  false,
 			ConstantFolding: false,
@@ -443,14 +438,14 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 		{
 			want: false,
 			expr: `(< age 18)`,
-			cc:   &CompileConfig{AllowUnknownSelectors: true},
+			cc:   NewCompileConfig(EnableStringSelectors),
 			vals: map[string]Value{
 				"age": int64(20),
 			},
 		},
 		{
 			expr:   `(< not_exist_key 18)`,
-			cc:     &CompileConfig{AllowUnknownSelectors: true},
+			cc:     NewCompileConfig(EnableStringSelectors),
 			errMsg: "selectorKey not exist",
 		},
 		{
@@ -470,7 +465,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
    (- 2 v3) (/ 6 3) 4)
  (* 5 -6 7)
 )`,
-			cc: &CompileConfig{AllowUnknownSelectors: true},
+			cc: NewCompileConfig(EnableStringSelectors),
 			vals: map[string]Value{
 				"v3": int64(3),
 			},
@@ -492,7 +487,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 300000
+		size          = 10000
 		level         = 53
 		step          = size / 100
 		showSample    = false
@@ -586,7 +581,6 @@ func TestRandomExpressions(t *testing.T) {
 				v := r.Intn(0b1000)
 				// combination of optimizations
 				cc := CopyCompileConfig(conf)
-				cc.CompileOptions[Debug] = true
 				cc.CompileOptions[Reordering] = v&0b1 != 0
 				cc.CompileOptions[FastEvaluation] = v&0b10 != 0
 				cc.CompileOptions[ConstantFolding] = v&0b100 != 0

--- a/engine_test.go
+++ b/engine_test.go
@@ -14,12 +14,13 @@ import (
 
 func TestDebug(t *testing.T) {
 	s := `
-	(or
-	 (and
-	   (= 1 1)
-	   (< 4 2)
-	   (!= 5 6))
-	 (eq 8 -8))
+	(not
+	(and
+	 (if T
+	   (!= 0 0)
+	   (= 0 0))
+	 (= 0 0)
+	 (= 0 0)))
 	`
 
 	//s := `(+ 1 2)`
@@ -72,17 +73,16 @@ func TestDebugCases(t *testing.T) {
 (not
   (and
     (if T
-      (!= 0 0)
-      (= 0 0))
-    (= 0 0)
-    (= 0 0)))`,
+      (!= 3 3)
+      (= 4 4))
+    (= 5 5)
+    (= 6 6)))`,
 			valMap: map[string]Value{
 				"T": true,
 				"F": false,
 			},
 		},
 		{
-			run:           ________RunThisOne________,
 			want:          false,
 			optimizeLevel: disable,
 			s: `
@@ -396,6 +396,7 @@ func TestDebugCases(t *testing.T) {
 			Reordering:      false,
 			FastEvaluation:  false,
 			ConstantFolding: false,
+			Debug:           true,
 		}
 
 		switch c.optimizeLevel {
@@ -491,7 +492,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 10000
+		size          = 300000
 		level         = 53
 		step          = size / 100
 		showSample    = false
@@ -585,6 +586,7 @@ func TestRandomExpressions(t *testing.T) {
 				v := r.Intn(0b1000)
 				// combination of optimizations
 				cc := CopyCompileConfig(conf)
+				cc.OptimizeOptions[Debug] = true
 				cc.OptimizeOptions[Reordering] = v&0b1 != 0
 				cc.OptimizeOptions[FastEvaluation] = v&0b10 != 0
 				cc.OptimizeOptions[ConstantFolding] = v&0b100 != 0

--- a/engine_test.go
+++ b/engine_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDebugCases(t *testing.T) {
-	const onlyAllowListCases = true
+	const onlyAllowListCases = false
 
 	type runThis string
 	const ________RunThisOne________ runThis = "________RunThisOne________"
@@ -374,7 +374,6 @@ func TestDebugCases(t *testing.T) {
 		cc := NewCompileConfig(options...)
 
 		ctx := NewCtxWithMap(cc, c.valMap)
-		ctx.Debug = true
 
 		expr, err := Compile(cc, c.s)
 		assertNil(t, err)

--- a/engine_test.go
+++ b/engine_test.go
@@ -25,7 +25,7 @@ func TestDebug(t *testing.T) {
 
 	//s := `(+ 1 2)`
 	expr, err := Compile(&CompileConfig{
-		OptimizeOptions: map[OptimizeOption]bool{
+		CompileOptions: map[CompileOption]bool{
 			ConstantFolding: false,
 			FastEvaluation:  false,
 			Reordering:      false,
@@ -392,7 +392,7 @@ func TestDebugCases(t *testing.T) {
 		}
 
 		cc := NewCompileConfig()
-		cc.OptimizeOptions = map[OptimizeOption]bool{
+		cc.CompileOptions = map[CompileOption]bool{
 			Reordering:      false,
 			FastEvaluation:  false,
 			ConstantFolding: false,
@@ -401,11 +401,11 @@ func TestDebugCases(t *testing.T) {
 
 		switch c.optimizeLevel {
 		case all:
-			cc.OptimizeOptions[Reordering] = true
-			cc.OptimizeOptions[ConstantFolding] = true
+			cc.CompileOptions[Reordering] = true
+			cc.CompileOptions[ConstantFolding] = true
 			fallthrough
 		case onlyFast:
-			cc.OptimizeOptions[FastEvaluation] = true
+			cc.CompileOptions[FastEvaluation] = true
 		case disable:
 		}
 
@@ -586,10 +586,10 @@ func TestRandomExpressions(t *testing.T) {
 				v := r.Intn(0b1000)
 				// combination of optimizations
 				cc := CopyCompileConfig(conf)
-				cc.OptimizeOptions[Debug] = true
-				cc.OptimizeOptions[Reordering] = v&0b1 != 0
-				cc.OptimizeOptions[FastEvaluation] = v&0b10 != 0
-				cc.OptimizeOptions[ConstantFolding] = v&0b100 != 0
+				cc.CompileOptions[Debug] = true
+				cc.CompileOptions[Reordering] = v&0b1 != 0
+				cc.CompileOptions[FastEvaluation] = v&0b10 != 0
+				cc.CompileOptions[ConstantFolding] = v&0b100 != 0
 				ctx := NewCtxWithMap(cc, valMap)
 				got, err := Eval(cc, expr.Expr, ctx)
 

--- a/parse.go
+++ b/parse.go
@@ -596,13 +596,13 @@ func (p *parser) parseConfig() error {
 			if err != nil {
 				return p.errWithToken(fmt.Errorf("invalid config value %s, err %w", s, err), t)
 			}
-			switch option := OptimizeOption(pair[0]); option {
+			switch option := CompileOption(pair[0]); option {
 			case AllOptimizations: // switch all optimizations
-				for _, option := range []OptimizeOption{Reordering, FastEvaluation, ConstantFolding} {
-					confCopy.OptimizeOptions[option] = enabled
+				for _, opt := range []CompileOption{Reordering, FastEvaluation, ConstantFolding} {
+					confCopy.CompileOptions[opt] = enabled
 				}
 			case Reordering, FastEvaluation, ConstantFolding:
-				confCopy.OptimizeOptions[option] = enabled
+				confCopy.CompileOptions[option] = enabled
 			default:
 				return p.errWithToken(fmt.Errorf("unsupported compile config %s", s), t)
 			}

--- a/parse.go
+++ b/parse.go
@@ -464,7 +464,7 @@ func (p *parser) parseExpression() (*astNode, error) {
 	}
 
 	if t := p.peek(); t.typ == ident {
-		if p.conf.AllowUnknownSelectors {
+		if p.conf.CompileOptions[AllowUnknownSelectors] {
 			p.walk()
 			return &astNode{
 				node: &node{
@@ -596,9 +596,9 @@ func (p *parser) parseConfig() error {
 			if err != nil {
 				return p.errWithToken(fmt.Errorf("invalid config value %s, err %w", s, err), t)
 			}
-			switch option := CompileOption(pair[0]); option {
+			switch option := Option(pair[0]); option {
 			case AllOptimizations: // switch all optimizations
-				for _, opt := range []CompileOption{Reordering, FastEvaluation, ConstantFolding} {
+				for _, opt := range []Option{Reordering, FastEvaluation, ConstantFolding} {
 					confCopy.CompileOptions[opt] = enabled
 				}
 			case Reordering, FastEvaluation, ConstantFolding:

--- a/parse.go
+++ b/parse.go
@@ -571,8 +571,8 @@ func (p *parser) parseConfig() error {
 
 	confCopy := CopyCompileConfig(p.conf)
 
-	for i := 0; i < len(p.tokens); i++ { // parse config
-		t := p.tokens[i]
+	// parse config
+	for _, t := range p.tokens {
 		if t.typ != comment {
 			break
 		}
@@ -597,8 +597,8 @@ func (p *parser) parseConfig() error {
 				return p.errWithToken(fmt.Errorf("invalid config value %s, err %w", s, err), t)
 			}
 			switch option := Option(pair[0]); option {
-			case AllOptimizations: // switch all optimizations
-				for _, opt := range []Option{Reordering, FastEvaluation, ConstantFolding} {
+			case Optimize: // switch all optimizations
+				for _, opt := range AllOptimizations {
 					confCopy.CompileOptions[opt] = enabled
 				}
 			case Reordering, FastEvaluation, ConstantFolding:

--- a/parse_test.go
+++ b/parse_test.go
@@ -462,31 +462,31 @@ func TestLex(t *testing.T) {
 func TestParseConfig(t *testing.T) {
 	testCases := []struct {
 		expr   string
-		origin map[CompileOption]bool
-		want   map[CompileOption]bool
+		origin map[Option]bool
+		want   map[Option]bool
 		errMsg string
 	}{
 		{
 			expr:   `(+ 1 1)`,
-			origin: map[CompileOption]bool{},
-			want:   map[CompileOption]bool{},
+			origin: map[Option]bool{},
+			want:   map[Option]bool{},
 		},
 		{
 			expr:   `;;;; constant_folding: true, reordering: true`,
-			origin: map[CompileOption]bool{},
-			want: map[CompileOption]bool{
+			origin: map[Option]bool{},
+			want: map[Option]bool{
 				Reordering:      true,
 				ConstantFolding: true,
 			},
 		},
 		{
 			expr: `;;;; optimize:false`,
-			origin: map[CompileOption]bool{
+			origin: map[Option]bool{
 				Reordering:      true,
 				FastEvaluation:  true,
 				ConstantFolding: true,
 			},
-			want: map[CompileOption]bool{
+			want: map[Option]bool{
 				Reordering:      false,
 				FastEvaluation:  false,
 				ConstantFolding: false,
@@ -499,12 +499,12 @@ func TestParseConfig(t *testing.T) {
 ;; then only enable reordering and constant_folding
 ;;;; reordering: true, constant_folding: true
 `,
-			origin: map[CompileOption]bool{
+			origin: map[Option]bool{
 				Reordering:      true,
 				FastEvaluation:  true,
 				ConstantFolding: true,
 			},
-			want: map[CompileOption]bool{
+			want: map[Option]bool{
 				Reordering:      true,
 				FastEvaluation:  false,
 				ConstantFolding: true,
@@ -513,7 +513,7 @@ func TestParseConfig(t *testing.T) {
 
 		{
 			expr: `;;;;unsupported_option:false`,
-			origin: map[CompileOption]bool{
+			origin: map[Option]bool{
 				Reordering:      true,
 				FastEvaluation:  true,
 				ConstantFolding: true,
@@ -523,7 +523,7 @@ func TestParseConfig(t *testing.T) {
 
 		{
 			expr: `;;;;reordering:disabled`,
-			origin: map[CompileOption]bool{
+			origin: map[Option]bool{
 				Reordering:      true,
 				FastEvaluation:  true,
 				ConstantFolding: true,
@@ -533,7 +533,7 @@ func TestParseConfig(t *testing.T) {
 
 		{
 			expr: `;;;;reordering:false:false`,
-			origin: map[CompileOption]bool{
+			origin: map[Option]bool{
 				Reordering:      true,
 				FastEvaluation:  true,
 				ConstantFolding: true,
@@ -800,13 +800,13 @@ func TestParseAstTree(t *testing.T) {
 			},
 		},
 		{
-			cc:     &CompileConfig{AllowUnknownSelectors: false},
+			cc:     NewCompileConfig(),
 			expr:   `(< age 18)`,
 			errMsg: "unknown token error",
 		},
 		// return an error when expr use unregister selector
 		{
-			cc:   &CompileConfig{AllowUnknownSelectors: true},
+			cc:   NewCompileConfig(EnableStringSelectors),
 			expr: `(< age 18)`,
 			ast: verifyNode{
 				tpy:  operator,

--- a/parse_test.go
+++ b/parse_test.go
@@ -462,31 +462,31 @@ func TestLex(t *testing.T) {
 func TestParseConfig(t *testing.T) {
 	testCases := []struct {
 		expr   string
-		origin map[OptimizeOption]bool
-		want   map[OptimizeOption]bool
+		origin map[CompileOption]bool
+		want   map[CompileOption]bool
 		errMsg string
 	}{
 		{
 			expr:   `(+ 1 1)`,
-			origin: map[OptimizeOption]bool{},
-			want:   map[OptimizeOption]bool{},
+			origin: map[CompileOption]bool{},
+			want:   map[CompileOption]bool{},
 		},
 		{
 			expr:   `;;;; constant_folding: true, reordering: true`,
-			origin: map[OptimizeOption]bool{},
-			want: map[OptimizeOption]bool{
+			origin: map[CompileOption]bool{},
+			want: map[CompileOption]bool{
 				Reordering:      true,
 				ConstantFolding: true,
 			},
 		},
 		{
 			expr: `;;;; optimize:false`,
-			origin: map[OptimizeOption]bool{
+			origin: map[CompileOption]bool{
 				Reordering:      true,
 				FastEvaluation:  true,
 				ConstantFolding: true,
 			},
-			want: map[OptimizeOption]bool{
+			want: map[CompileOption]bool{
 				Reordering:      false,
 				FastEvaluation:  false,
 				ConstantFolding: false,
@@ -499,12 +499,12 @@ func TestParseConfig(t *testing.T) {
 ;; then only enable reordering and constant_folding
 ;;;; reordering: true, constant_folding: true
 `,
-			origin: map[OptimizeOption]bool{
+			origin: map[CompileOption]bool{
 				Reordering:      true,
 				FastEvaluation:  true,
 				ConstantFolding: true,
 			},
-			want: map[OptimizeOption]bool{
+			want: map[CompileOption]bool{
 				Reordering:      true,
 				FastEvaluation:  false,
 				ConstantFolding: true,
@@ -513,7 +513,7 @@ func TestParseConfig(t *testing.T) {
 
 		{
 			expr: `;;;;unsupported_option:false`,
-			origin: map[OptimizeOption]bool{
+			origin: map[CompileOption]bool{
 				Reordering:      true,
 				FastEvaluation:  true,
 				ConstantFolding: true,
@@ -523,7 +523,7 @@ func TestParseConfig(t *testing.T) {
 
 		{
 			expr: `;;;;reordering:disabled`,
-			origin: map[OptimizeOption]bool{
+			origin: map[CompileOption]bool{
 				Reordering:      true,
 				FastEvaluation:  true,
 				ConstantFolding: true,
@@ -533,7 +533,7 @@ func TestParseConfig(t *testing.T) {
 
 		{
 			expr: `;;;;reordering:false:false`,
-			origin: map[OptimizeOption]bool{
+			origin: map[CompileOption]bool{
 				Reordering:      true,
 				FastEvaluation:  true,
 				ConstantFolding: true,
@@ -543,7 +543,7 @@ func TestParseConfig(t *testing.T) {
 	}
 
 	for _, c := range testCases {
-		p := newParser(&CompileConfig{OptimizeOptions: c.origin}, c.expr)
+		p := newParser(&CompileConfig{CompileOptions: c.origin}, c.expr)
 		err := p.lex()
 		assertNil(t, err, c)
 		err = p.parseConfig()
@@ -552,7 +552,7 @@ func TestParseConfig(t *testing.T) {
 			continue
 		}
 		assertNil(t, err, c)
-		updatedOption := p.conf.OptimizeOptions
+		updatedOption := p.conf.CompileOptions
 
 		for option, want := range c.want {
 			got, exist := updatedOption[option]

--- a/selector.go
+++ b/selector.go
@@ -79,7 +79,6 @@ func NewCtxWithMap(cc *CompileConfig, vals map[string]Value) *Ctx {
 	}
 
 	return &Ctx{
-		Debug:    false,
 		Selector: sel,
 	}
 }

--- a/util.go
+++ b/util.go
@@ -545,9 +545,6 @@ func PrintExpr(expr *Expr, fields ...string) string {
 	}
 
 	size := len(expr.nodes)
-	if expr.nodes[0].flag == debug {
-		size = size / 2
-	}
 	var sb strings.Builder
 
 	sb.WriteString(fmt.Sprintf("node  size: %4d\n", len(expr.nodes)))

--- a/util.go
+++ b/util.go
@@ -484,11 +484,13 @@ func PrintExpr(expr *Expr, fields ...string) string {
 			case selector:
 				res = "S"
 			case constant:
-				res = "V"
+				res = "C"
 			case cond:
 				res = "IF"
 			case end:
 				res = "END"
+			case debug:
+				res = "D"
 			}
 			return res
 		},
@@ -532,6 +534,9 @@ func PrintExpr(expr *Expr, fields ...string) string {
 	}
 
 	size := len(expr.nodes)
+	if expr.nodes[0].flag == debug {
+		size = size / 2
+	}
 	var sb strings.Builder
 
 	sb.WriteString(fmt.Sprintf("node  size: %4d\n", len(expr.nodes)))

--- a/util.go
+++ b/util.go
@@ -365,6 +365,15 @@ func IndentByParentheses(s string) string {
 }
 
 func Dump(e *Expr) string {
+	var getNode = func(idx int) *node {
+		n := e.nodes[idx]
+		if n.getNodeType() != debug {
+			return n
+		}
+		offset := len(e.nodes) / 2
+		return e.nodes[idx+offset]
+	}
+
 	var helper func(*node) (string, bool)
 
 	helper = func(root *node) (string, bool) {
@@ -376,7 +385,7 @@ func Dump(e *Expr) string {
 		sb.WriteString(fmt.Sprintf("(%v", root.value))
 		for i := 0; i < int(root.childCnt); i++ {
 			childIdx := int(root.childIdx) + i
-			child := e.nodes[childIdx]
+			child := getNode(childIdx)
 			if child.getNodeType() == end {
 				continue
 			}
@@ -394,12 +403,14 @@ func Dump(e *Expr) string {
 		return sb.String(), false
 	}
 
-	res, _ := helper(e.nodes[0])
+	res, _ := helper(getNode(0))
 	return res
 }
 
 func dumpLeafNode(node *node) (string, bool) {
 	switch node.getNodeType() {
+	case debug:
+		return "debug", false
 	case end:
 		return "", true
 	case selector:

--- a/util_test.go
+++ b/util_test.go
@@ -155,7 +155,7 @@ func TestGenerateRandomExpr_Bool(t *testing.T) {
 			"T": SelectorKey(1),
 			"F": SelectorKey(2),
 		},
-		CompileOptions: map[CompileOption]bool{
+		CompileOptions: map[Option]bool{
 			ConstantFolding: false,
 		},
 	}
@@ -209,7 +209,7 @@ func TestGenerateRandomExpr_Number(t *testing.T) {
 
 	cc := &CompileConfig{
 		SelectorMap: keyMap,
-		CompileOptions: map[CompileOption]bool{
+		CompileOptions: map[Option]bool{
 			ConstantFolding: false,
 		},
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -155,7 +155,7 @@ func TestGenerateRandomExpr_Bool(t *testing.T) {
 			"T": SelectorKey(1),
 			"F": SelectorKey(2),
 		},
-		OptimizeOptions: map[OptimizeOption]bool{
+		CompileOptions: map[CompileOption]bool{
 			ConstantFolding: false,
 		},
 	}
@@ -209,7 +209,7 @@ func TestGenerateRandomExpr_Number(t *testing.T) {
 
 	cc := &CompileConfig{
 		SelectorMap: keyMap,
-		OptimizeOptions: map[OptimizeOption]bool{
+		CompileOptions: map[CompileOption]bool{
 			ConstantFolding: false,
 		},
 	}


### PR DESCRIPTION
## Summary
This PR adds a new node type `debug` to reduce the number of executing `if (debug)`, and results the improvement of performance.

```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/larry618/eval_bench
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16     	42869725	        77.22 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16      	42998332	        81.27 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16    	44294011	        78.11 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16     	43094262	        81.65 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/larry618/eval_bench	14.497s
```

## Test Plan
- [x] Unit test passed
```
❯ go test
PASS
ok  	github.com/larry618/eval	1.864s
```

- [X] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/larry618/eval_bench
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16     	40612315	        80.35 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16      	43368852	        82.93 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16    	44388733	        79.61 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16     	42563108	        82.09 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/larry618/eval_bench	14.637s
```

- [x] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     37681|     30000|      5248|        33|    3.399s|
|       2 %|       2 %|     68633|     60000|      6156|        77|    3.679s|
|       3 %|       3 %|     92310|     90000|         0|         0|    3.955s|
|       4 %|       4 %|    122452|    120000|        34|        18|    4.056s|
|       5 %|       5 %|    152654|    150000|       132|       122|    4.255s|
|       6 %|       6 %|    183893|    180000|      1426|        67|    4.305s|
|       7 %|       7 %|    212495|    210000|        87|         8|    4.059s|
|       8 %|       8 %|    242408|    240000|         0|        18|    4.146s|
|       9 %|       9 %|    272854|    270000|       353|       101|    4.096s|
|      10 %|      10 %|    322400|    300000|     10000|     10000|    6.022s|
|      11 %|      11 %|    336356|    330000|      3834|       122|    2.505s|
|      12 %|      12 %|    364716|    360000|      2243|        73|    4.174s|
|      13 %|      13 %|    394358|    390000|      1860|        98|    4.158s|
|      14 %|      14 %|    422552|    420000|        68|        84|    4.362s|
|      15 %|      15 %|    452511|    450000|        46|        65|    4.362s|
|      16 %|      16 %|    482442|    480000|        39|         3|    4.353s|
|      17 %|      17 %|    512453|    510000|         0|        56|    4.395s|
|      18 %|      18 %|    542440|    540000|         9|        31|     4.63s|
|      19 %|      19 %|    572634|    570000|       112|       122|    4.652s|
|      20 %|      20 %|    605364|    600000|      2281|       683|    4.834s|
|      21 %|      21 %|    636467|    630000|      3997|        70|    4.438s|
|      22 %|      22 %|    662598|    660000|       173|        25|    4.271s|
|      23 %|      23 %|    692800|    690000|       203|       197|    4.726s|
|      24 %|      24 %|    723224|    720000|       774|        50|    4.255s|
|      25 %|      25 %|    752387|    750000|         0|         0|    4.422s|
|      26 %|      26 %|    782488|    780000|        57|        31|    4.353s|
|      27 %|      27 %|    812578|    810000|       161|        17|    4.646s|
|      28 %|      28 %|    842410|    840000|         3|         7|    4.631s|
|      29 %|      29 %|    872532|    870000|        34|        98|    4.803s|
|      30 %|      30 %|    902935|    900000|       430|       105|    5.137s|
|      31 %|      31 %|    936030|    930000|      3556|        74|    4.899s|
|      32 %|      32 %|    962527|    960000|        39|        88|    4.667s|
|      33 %|      33 %|    992717|    990000|       136|       181|    4.766s|
|      34 %|      34 %|   1023904|   1020000|      1379|       125|    4.645s|
|      35 %|      35 %|   1052623|   1050000|        45|       178|    4.607s|
|      36 %|      36 %|   1082997|   1080000|       365|       232|    4.709s|
|      37 %|      37 %|   1112504|   1110000|        99|         5|    4.533s|
|      38 %|      38 %|   1144693|   1140000|      2253|        40|    4.626s|
|      39 %|      39 %|   1172609|   1170000|       180|        29|    4.733s|
|      40 %|      40 %|   1202755|   1200000|       245|       110|    4.716s|
|      41 %|      41 %|   1233202|   1230000|       800|         2|    4.786s|
|      42 %|      42 %|   1262601|   1260000|       107|        94|    4.729s|
|      43 %|      43 %|   1292646|   1290000|       135|       111|    4.679s|
|      44 %|      44 %|   1323070|   1320000|       507|       163|    4.559s|
|      45 %|      45 %|   1352963|   1350000|       468|        95|    4.501s|
|      46 %|      46 %|   1382875|   1380000|       411|        64|    4.606s|
|      47 %|      47 %|   1412910|   1410000|       162|       348|    4.661s|
|      48 %|      48 %|   1442572|   1440000|        99|        73|     4.68s|
|      49 %|      49 %|   1472443|   1470000|         1|        42|    4.817s|
|      50 %|      50 %|   1502678|   1500000|       228|        50|    4.882s|
|      51 %|      51 %|   1533052|   1530000|       529|       123|    4.681s|
|      52 %|      52 %|   1562587|   1560000|       167|        20|    4.772s|
|      53 %|      53 %|   1592543|   1590000|         0|       159|    4.757s|
|      54 %|      54 %|   1622397|   1620000|         0|         0|    4.653s|
|      55 %|      55 %|   1652731|   1650000|       139|       192|    4.891s|
|      56 %|      56 %|   1682702|   1680000|       301|         1|     4.73s|
|      57 %|      57 %|   1712481|   1710000|        24|        57|    4.634s|
|      58 %|      58 %|   1745070|   1740000|      2630|        40|    4.655s|
|      59 %|      59 %|   1772595|   1770000|       144|        51|     4.53s|
|      60 %|      60 %|   1802631|   1800000|       208|        23|    4.537s|
|      61 %|      61 %|   1833100|   1830000|       330|       370|    4.713s|
|      62 %|      62 %|   1862524|   1860000|        53|        71|    4.753s|
|      63 %|      63 %|   1893950|   1890000|      1538|        12|    4.743s|
|      64 %|      64 %|   1922519|   1920000|        36|        83|    4.658s|
|      65 %|      65 %|   1952673|   1950000|       264|         9|    4.809s|
|      66 %|      66 %|   1982675|   1980000|         0|       275|     4.73s|
|      67 %|      67 %|   2012696|   2010000|        75|       221|    4.715s|
|      68 %|      68 %|   2042563|   2040000|       110|        53|    4.598s|
|      69 %|      69 %|   2072505|   2070000|         0|       111|     4.78s|
|      70 %|      70 %|   2103090|   2100000|       529|       161|    4.711s|
|      71 %|      71 %|   2133128|   2130000|       686|        42|    4.718s|
|      72 %|      72 %|   2162769|   2160000|       369|         0|     4.78s|
|      73 %|      73 %|   2193002|   2190000|       560|        42|    4.805s|
|      74 %|      74 %|   2224000|   2220000|       632|       968|    4.927s|
|      75 %|      75 %|   2252758|   2250000|        75|       283|    4.492s|
|      76 %|      76 %|   2282431|   2280000|        31|         0|    4.691s|
|      77 %|      77 %|   2312636|   2310000|       232|         4|    4.641s|
|      78 %|      78 %|   2344208|   2340000|      1777|        31|     4.83s|
|      79 %|      79 %|   2372852|   2370000|       410|        42|     4.73s|
|      80 %|      80 %|   2402993|   2400000|       461|       132|     4.74s|
|      81 %|      81 %|   2433408|   2430000|       988|        20|    4.776s|
|      82 %|      82 %|   2462576|   2460000|        83|        93|    4.779s|
|      83 %|      83 %|   2492695|   2490000|       220|        75|    4.655s|
|      84 %|      84 %|   2522420|   2520000|        10|        10|    4.748s|
|      85 %|      85 %|   2552649|   2550000|       196|        53|    4.791s|
|      86 %|      86 %|   2583475|   2580000|      1071|         4|    4.711s|
|      87 %|      87 %|   2615057|   2610000|      2441|       216|     4.82s|
|      88 %|      88 %|   2642526|   2640000|       112|        14|    4.556s|
|      89 %|      89 %|   2672735|   2670000|       223|       112|    4.749s|
|      90 %|      90 %|   2702513|   2700000|        12|       101|    4.646s|
|      91 %|      91 %|   2732589|   2730000|       149|        41|    4.718s|
|      92 %|      92 %|   2762502|   2760000|        92|        10|    4.771s|
|      93 %|      93 %|   2792823|   2790000|       307|       116|     4.82s|
|      94 %|      94 %|   2825042|   2820000|      2509|       133|    4.766s|
|      95 %|      95 %|   2852506|   2850000|         0|       108|    4.627s|
|      96 %|      96 %|   2882803|   2880000|       359|        44|    4.924s|
|      97 %|      97 %|   2912608|   2910000|        53|       155|    4.894s|
|      98 %|      98 %|   2942713|   2940000|       229|        84|    4.661s|
|      99 %|      99 %|   2972598|   2970000|       165|        33|    4.771s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|    5.093s|
PASS
ok  	github.com/larry618/eval	461.805s
```
- [x] Tested on 300000 random expressions with debug option
```
❯ go test -run='TestRandomExpressions' | grep -v "Stack Frame" | grep "%|"
|       5 %|       1 %|     15452|      3000|     10000|        52|    1.489s|
|       6 %|       2 %|     18399|      6000|     10000|         0|    2.744s|
|       7 %|       3 %|     21399|      9000|     10000|         0|    3.586s|
|       8 %|       4 %|     24399|     12000|     10000|         0|    4.733s|
|       9 %|       5 %|     27399|     15000|     10000|         0|    4.588s|
|      10 %|       6 %|     30399|     18000|     10000|         1|     4.89s|
|      11 %|       7 %|     33399|     21000|     10000|         0|    5.155s|
|      12 %|       8 %|     36399|     24000|     10000|         0|    5.738s|
|      13 %|       9 %|     39399|     27000|     10000|         0|    5.251s|
|      14 %|      10 %|     42399|     30000|     10000|         0|    5.253s|
|      15 %|      11 %|     45399|     33000|     10000|         0|    5.141s|
|      16 %|      12 %|     48399|     36000|     10000|         0|    5.261s|
|      17 %|      13 %|     51399|     39000|     10000|         0|    5.191s|
|      18 %|      14 %|     54400|     42000|     10000|         3|    5.846s|
|      19 %|      15 %|     57399|     45000|     10000|         0|    5.062s|
|      20 %|      16 %|     60399|     48000|     10000|         0|    5.019s|
|      21 %|      17 %|     63399|     51000|     10000|         0|    5.335s|
|      22 %|      18 %|     66399|     54000|     10000|         0|    4.666s|
|      23 %|      19 %|     69399|     57000|     10000|         0|    5.134s|
|      24 %|      20 %|     72399|     60000|     10000|         0|    5.095s|
|      25 %|      21 %|     75399|     63000|     10000|         0|    5.501s|
|      26 %|      22 %|     78399|     66000|     10000|         0|    5.373s|
|      27 %|      23 %|     81399|     69000|     10000|         0|    5.079s|
|      28 %|      24 %|     84399|     72000|     10000|         0|    5.422s|
|      29 %|      25 %|     87399|     75000|     10000|         0|    5.354s|
|      30 %|      26 %|     90399|     78000|     10000|         0|    5.367s|
|      31 %|      27 %|     93399|     81000|     10000|         0|    4.891s|
|      32 %|      28 %|     96399|     84000|     10000|         0|    4.991s|
|      33 %|      29 %|     99399|     87000|     10000|         0|    5.495s|
|      34 %|      30 %|    102399|     90000|     10000|         0|    5.926s|
|      35 %|      31 %|    105399|     93000|     10000|         0|     5.03s|
|      36 %|      32 %|    108399|     96000|     10000|         0|    5.147s|
|      37 %|      33 %|    111399|     99000|     10000|         0|    5.151s|
|      38 %|      34 %|    114399|    102000|     10000|         0|    5.269s|
|      39 %|      35 %|    117401|    105000|     10000|         5|    5.892s|
|      40 %|      36 %|    120399|    108000|     10000|         0|    5.829s|
|      41 %|      37 %|    123399|    111000|     10000|         0|    6.384s|
|      42 %|      38 %|    126399|    114000|     10000|         0|    5.778s|
|      43 %|      39 %|    129399|    117000|     10000|         0|    5.889s|
|      44 %|      40 %|    132399|    120000|     10000|         0|    5.948s|
|      45 %|      41 %|    135399|    123000|     10000|         0|    6.161s|
|      46 %|      42 %|    138399|    126000|     10000|         0|    5.265s|
|      47 %|      43 %|    141399|    129000|     10000|         0|    5.636s|
|      48 %|      44 %|    144399|    132000|     10000|         0|    5.286s|
|      49 %|      45 %|    147399|    135000|     10000|         0|    5.527s|
|      50 %|      46 %|    150399|    138000|     10000|         0|    5.336s|
|      51 %|      47 %|    153399|    141000|     10000|         0|    5.432s|
|      52 %|      48 %|    156400|    144000|     10000|         0|    5.033s|
|      53 %|      49 %|    159399|    147000|     10000|         0|    5.178s|
|      54 %|      50 %|    162399|    150000|     10000|         0|    5.183s|
|      55 %|      51 %|    165399|    153000|     10000|         0|     5.02s|
|      56 %|      52 %|    168399|    156000|     10000|         0|    5.075s|
|      57 %|      53 %|    171399|    159000|     10000|         0|    4.983s|
|      58 %|      54 %|    174399|    162000|     10000|         0|    5.021s|
|      59 %|      55 %|    177399|    165000|     10000|         0|    5.201s|
|      60 %|      56 %|    180399|    168000|     10000|         0|    5.462s|
|      61 %|      57 %|    183399|    171000|     10000|         0|    5.657s|
|      62 %|      58 %|    186399|    174000|     10000|         0|    7.201s|
|      63 %|      59 %|    189399|    177000|     10000|         0|    6.667s|
|      64 %|      60 %|    192399|    180000|     10000|         0|    6.674s|
|      65 %|      61 %|    195399|    183000|     10000|         0|    6.121s|
|      66 %|      62 %|    198399|    186000|     10000|         0|    6.051s|
|      67 %|      63 %|    201399|    189000|     10000|         0|     5.48s|
|      68 %|      64 %|    204399|    192000|     10000|         0|    5.129s|
|      69 %|      65 %|    207399|    195000|     10000|         0|     5.35s|
|      70 %|      66 %|    210399|    198000|     10000|         0|    5.172s|
|      71 %|      67 %|    213399|    201000|     10000|         0|    5.742s|
|      72 %|      68 %|    216399|    204000|     10000|         0|    7.977s|
|      73 %|      69 %|    219399|    207000|     10000|         0|    5.965s|
|      74 %|      70 %|    222399|    210000|     10000|         0|    5.534s|
|      75 %|      71 %|    225399|    213000|     10000|         0|    7.216s|
|      76 %|      72 %|    228399|    216000|     10000|         0|     6.04s|
|      77 %|      73 %|    231399|    219000|     10000|         0|    5.943s|
|      78 %|      74 %|    234399|    222000|     10000|         0|    5.684s|
|      79 %|      75 %|    237399|    225000|     10000|         0|      5.6s|
|      80 %|      76 %|    240399|    228000|     10000|         0|    5.374s|
|      81 %|      77 %|    243399|    231000|     10000|         0|    5.825s|
|      82 %|      78 %|    246399|    234000|     10000|         0|    5.411s|
|      83 %|      79 %|    249399|    237000|     10000|         0|    5.521s|
|      84 %|      80 %|    252399|    240000|     10000|         0|    4.997s|
|      85 %|      81 %|    255399|    243000|     10000|         0|    5.216s|
|      86 %|      82 %|    258399|    246000|     10000|         0|    5.197s|
|      87 %|      83 %|    261399|    249000|     10000|         0|    5.201s|
|      88 %|      84 %|    264399|    252000|     10000|         0|    5.346s|
|      89 %|      85 %|    267399|    255000|     10000|         0|    5.226s|
|      90 %|      86 %|    270399|    258000|     10000|         0|    5.169s|
|      91 %|      87 %|    273399|    261000|     10000|         0|    5.174s|
|      92 %|      88 %|    276399|    264000|     10000|         0|    5.194s|
|      93 %|      89 %|    279398|    267000|     10000|         0|    4.942s|
|      94 %|      90 %|    282399|    270000|     10000|         0|    5.382s|
|      95 %|      91 %|    285399|    273000|     10000|         0|    5.654s|
|      96 %|      92 %|    288399|    276000|     10000|         0|    6.008s|
|      97 %|      93 %|    291399|    279000|     10000|         0|    6.132s|
|      98 %|      94 %|    294399|    282000|     10000|         0|    5.869s|
|      99 %|      95 %|    297399|    285000|     10000|         0|    6.193s|
|     100 %|      96 %|    300000|    288000|     10000|         0|    5.802s|
|     100 %|      97 %|    300000|    291000|      7000|         0|    6.083s|
|     100 %|      98 %|    300000|    294000|      4000|         0|    6.765s|
|     100 %|      99 %|    300000|    297000|      1000|         0|    5.911s|
|     100 %|     100 %|    300000|    300000|         0|         0|   14.647s|
```


## Reviewers
@larry618