### PR TITLE
[engine] simple refactor

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -130,7 +130,10 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 	)
 
 	// push the root node to the stack frame
-	sf[sfTop+1], sfTop = 0, sfTop+1
+	// just increase the sfTop because the index of root node is zero,
+	// so we don't need to actually push zero to stack
+	// e.g. sf[sfTop+1], sfTop = 0, sfTop+1
+	sfTop = 0
 
 	for sfTop != -1 { // while stack frame is not empty
 		curtIdx, sfTop = sf[sfTop], sfTop-1
@@ -235,7 +238,7 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 			res, osTop = os[osTop], osTop-1
 		default:
 			// only debug node will enter this branch
-			offset := int16(len(e.nodes)) / 2
+			offset := int16(len(nodes)) / 2
 			debugStackFrame(sf, sfTop, offset)
 
 			// push the real node to print stacks
@@ -315,12 +318,12 @@ func getNodeValue(ctx *Ctx, n *node) (res Value, err error) {
 func getSelectorValue(ctx *Ctx, n *node) (res Value, err error) {
 	res, err = ctx.Get(n.selKey, n.value.(string))
 	if err != nil {
-		return nil, err
+		return
 	}
 
 	switch res.(type) {
 	case bool, string, int64, []int64, []string:
-		return res, nil
+		return
 	default:
 		return unifyType(res), nil
 	}

--- a/util.go
+++ b/util.go
@@ -459,6 +459,14 @@ func max(a, b int) int {
 	}
 }
 
+func maxInt16(a, b int16) int16 {
+	if a > b {
+		return a
+	} else {
+		return b
+	}
+}
+
 func PrintExpr(expr *Expr, fields ...string) string {
 	type fetcher func(e *Expr, i int) Value
 	const (


### PR DESCRIPTION
## Summary
This PR does the following changes.
1. Replace int with int16 to avoid extra type conversions
2. Set `sfTop` to `0` directly instead of actually pushing `0` to the stack frame.

## Test Plan
- [X] Unit test passed
```
❯ go test
PASS
ok  	github.com/larry618/eval	1.842s
```

- [X] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/larry618/eval_bench
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16     	40863950	        82.36 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16      	42504450	        83.27 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16    	43490090	        80.85 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16     	42263746	        84.03 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/larry618/eval_bench	15.094s
```

- [X] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     32684|     30000|       185|        99|    2.078s|
|       2 %|       2 %|     72381|     60000|      9863|       118|    3.799s|
|       3 %|       3 %|     98731|     90000|      6041|       290|    3.945s|
|       4 %|       4 %|    124580|    120000|      2106|        74|    4.211s|
|       5 %|       5 %|    153961|    150000|      1513|        48|    3.979s|
|       6 %|       6 %|    182474|    180000|         0|        90|    4.015s|
|       7 %|       7 %|    212660|    210000|       243|        17|    4.124s|
|       8 %|       8 %|    243202|    240000|       687|       115|    4.166s|
|       9 %|       9 %|    273937|    270000|      1364|       173|    4.196s|
|      10 %|      10 %|    302455|    300000|        51|         4|    4.125s|
|      11 %|      11 %|    333071|    330000|       450|       221|    4.311s|
|      12 %|      12 %|    362775|    360000|       286|        89|    4.435s|
|      13 %|      13 %|    395040|    390000|      2623|        17|    4.225s|
|      14 %|      14 %|    422460|    420000|         0|        64|    4.153s|
|      15 %|      15 %|    452877|    450000|       178|       299|    4.209s|
|      16 %|      16 %|    482457|    480000|         1|        56|    4.364s|
|      17 %|      17 %|    512509|    510000|        56|        53|    4.193s|
|      18 %|      18 %|    543399|    540000|       913|        86|    4.325s|
|      19 %|      19 %|    572684|    570000|       205|        79|     4.29s|
|      20 %|      20 %|    602446|    600000|         0|        57|    4.248s|
|      21 %|      21 %|    632423|    630000|        18|         5|     4.32s|
|      22 %|      22 %|    664866|    660000|      2390|        76|    4.253s|
|      23 %|      23 %|    692463|    690000|        27|        36|    4.084s|
|      24 %|      24 %|    723896|    720000|      1357|       139|    4.226s|
|      25 %|      25 %|    754063|    750000|      1574|        89|    4.303s|
|      26 %|      26 %|    782788|    780000|       354|        34|    4.059s|
|      27 %|      27 %|    812962|    810000|       449|       113|    4.227s|
|      28 %|      28 %|    842745|    840000|       177|       168|    4.215s|
|      29 %|      29 %|    872509|    870000|       106|         3|    4.051s|
|      30 %|      30 %|    902425|    900000|        20|         5|    4.155s|
|      31 %|      31 %|    932481|    930000|        79|         2|    4.192s|
|      32 %|      32 %|    962501|    960000|        95|         6|    4.173s|
|      33 %|      33 %|    992627|    990000|       149|        78|    4.151s|
|      34 %|      34 %|   1022546|   1020000|        15|       131|    4.074s|
|      35 %|      35 %|   1052919|   1050000|       344|       175|    4.077s|
|      36 %|      36 %|   1082517|   1080000|        42|        75|    4.338s|
|      37 %|      37 %|   1112678|   1110000|       214|        64|    4.505s|
|      38 %|      38 %|   1142609|   1140000|       115|        94|    4.511s|
|      39 %|      39 %|   1172683|   1170000|       128|       155|    4.665s|
|      40 %|      40 %|   1202613|   1200000|       208|         5|     4.65s|
|      41 %|      41 %|   1232551|   1230000|       106|        45|    4.706s|
|      42 %|      42 %|   1262504|   1260000|        69|        35|    4.562s|
|      43 %|      43 %|   1312400|   1290000|     10000|     10000|    6.429s|
|      44 %|      44 %|   1331235|   1320000|      8835|         0|    2.687s|
|      45 %|      45 %|   1355018|   1350000|      2360|       258|    4.158s|
|      46 %|      46 %|   1382546|   1380000|        97|        49|    4.174s|
|      47 %|      47 %|   1412489|   1410000|        43|        46|    4.469s|
|      48 %|      48 %|   1443029|   1440000|       428|       201|    4.519s|
|      49 %|      49 %|   1472418|   1470000|         7|        11|    4.445s|
|      50 %|      50 %|   1502968|   1500000|       529|        39|    4.466s|
|      51 %|      51 %|   1532858|   1530000|       267|       191|    4.534s|
|      52 %|      52 %|   1565032|   1560000|      2471|       161|    4.433s|
|      53 %|      53 %|   1592522|   1590000|       122|         0|    4.462s|
|      54 %|      54 %|   1622722|   1620000|        96|       226|    4.631s|
|      55 %|      55 %|   1652841|   1650000|       283|       158|    4.339s|
|      56 %|      56 %|   1682942|   1680000|       366|       176|    4.428s|
|      57 %|      57 %|   1712635|   1710000|        46|       189|    4.309s|
|      58 %|      58 %|   1742837|   1740000|       431|         6|    4.394s|
|      59 %|      59 %|   1773001|   1770000|       435|       166|    4.544s|
|      60 %|      60 %|   1802509|   1800000|       107|         2|    4.474s|
|      61 %|      61 %|   1832514|   1830000|        87|        27|    4.499s|
|      62 %|      62 %|   1862777|   1860000|        48|       329|    4.502s|
|      63 %|      63 %|   1892723|   1890000|       307|        16|    4.466s|
|      64 %|      64 %|   1922611|   1920000|       140|        71|    4.529s|
|      65 %|      65 %|   1953001|   1950000|       400|       201|    4.486s|
|      66 %|      66 %|   1982725|   1980000|        33|       292|    4.483s|
|      67 %|      67 %|   2012663|   2010000|       108|       155|    4.511s|
|      68 %|      68 %|   2042921|   2040000|       480|        41|    4.549s|
|      69 %|      69 %|   2072445|   2070000|         0|        47|    4.457s|
|      70 %|      70 %|   2103211|   2100000|       280|       531|    4.642s|
|      71 %|      71 %|   2132620|   2130000|       185|        35|     4.53s|
|      72 %|      72 %|   2162489|   2160000|        73|        16|    4.487s|
|      73 %|      73 %|   2192658|   2190000|        71|       187|    4.488s|
|      74 %|      74 %|   2222554|   2220000|        10|       144|     4.56s|
|      75 %|      75 %|   2252572|   2250000|        28|       144|     4.47s|
|      76 %|      76 %|   2282929|   2280000|       513|        16|    4.476s|
|      77 %|      77 %|   2312494|   2310000|        18|        76|    4.542s|
|      78 %|      78 %|   2342459|   2340000|        55|         4|    4.521s|
|      79 %|      79 %|   2373656|   2370000|      1229|        27|    4.561s|
|      80 %|      80 %|   2402740|   2400000|       211|       129|    4.524s|
|      81 %|      81 %|   2432443|   2430000|         0|        46|    4.489s|
|      82 %|      82 %|   2462449|   2460000|        41|         8|    4.547s|
|      83 %|      83 %|   2494430|   2490000|      1917|       113|    4.533s|
|      84 %|      84 %|   2522636|   2520000|         2|       234|    4.502s|
|      85 %|      85 %|   2553200|   2550000|       790|        10|    4.618s|
|      86 %|      86 %|   2583036|   2580000|       151|       485|    4.658s|
|      87 %|      87 %|   2612875|   2610000|       359|       116|    4.553s|
|      88 %|      88 %|   2642710|   2640000|       293|        17|    4.632s|
|      89 %|      89 %|   2672544|   2670000|        58|        86|    4.774s|
|      90 %|      90 %|   2702619|   2700000|       157|        62|    4.655s|
|      91 %|      91 %|   2732440|   2730000|         0|        46|     4.65s|
|      92 %|      92 %|   2762660|   2760000|       140|       120|    4.655s|
|      93 %|      93 %|   2792871|   2790000|       471|         0|    4.575s|
|      94 %|      94 %|   2822715|   2820000|       262|        53|    4.531s|
|      95 %|      95 %|   2852502|   2850000|         0|       103|    4.671s|
|      96 %|      96 %|   2882448|   2880000|        15|        33|    4.399s|
|      97 %|      97 %|   2912968|   2910000|       153|       415|    4.655s|
|      98 %|      98 %|   2942550|   2940000|       126|        24|    4.502s|
|      99 %|      99 %|   2972711|   2970000|       128|       183|    4.614s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|    5.016s|
PASS
ok  	github.com/larry618/eval	440.597s

```

## Reviewers
@larry618