### PR TITLE
[compile] [engine] use bytecode in execution

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -448,6 +448,7 @@ func calAndSetBytecode(e *Expr) {
 
 	for idx, n := range e.nodes {
 		i := idx * align
+		p := int16(e.parentIdx[idx]) * align
 
 		switch n.getNodeType() {
 		case constant:
@@ -462,6 +463,12 @@ func calAndSetBytecode(e *Expr) {
 			e.bytecode[i+rIdx] = setOperator(n.value.(string), n.operator)
 			e.bytecode[i+cIdx] = int16(n.childIdx * align)
 			e.bytecode[i+cCnt] = int16(n.childCnt)
+		case cond:
+			e.bytecode[i+flag] = n.flag
+			e.bytecode[i+cIdx] = int16(n.childIdx * align)
+		case end:
+			e.bytecode[i+flag] = n.flag
+			e.bytecode[i+pIdx] = p
 		}
 
 		e.bytecode[i+fSfTop] = int16(e.sfSize[idx] - 2)
@@ -469,7 +476,6 @@ func calAndSetBytecode(e *Expr) {
 		e.bytecode[i+tSfTop] = int16(e.sfSize[idx] - 2)
 		e.bytecode[i+tOsTop] = int16(e.osSize[idx] - 1)
 
-		p := e.parentIdx[idx] * align
 		if n.flag&scIfFalse == scIfFalse {
 			e.bytecode[i+fSfTop] = e.bytecode[p+fSfTop]
 			e.bytecode[i+fOsTop] = e.bytecode[p+fOsTop]

--- a/compile.go
+++ b/compile.go
@@ -695,7 +695,7 @@ func optimizeFastEvaluation(cc *CompileConfig, root *astNode) {
 		optimizeFastEvaluation(cc, child)
 	}
 	n := root.node
-	if (n.flag&nodeTypeMask) != operator || n.childCnt != 2 {
+	if (n.flag&nodeTypeMask) != operator || len(root.children) != 2 {
 		return
 	}
 

--- a/compile.go
+++ b/compile.go
@@ -447,23 +447,27 @@ func calAndSetBytecode(e *Expr) {
 	)
 
 	for i, n := range e.nodes {
-		var third int16
-		var forth int16
+		i = i * align
+
 		switch n.getNodeType() {
 		case constant:
-			third = setConstant(n.value)
+			e.bytecode[i+flag] = n.flag
+			e.bytecode[i+rIdx] = setConstant(n.value)
 		case selector:
-			third = setConstant(n.value)
-			forth = int16(n.selKey)
+			e.bytecode[i+flag] = n.flag
+			e.bytecode[i+rIdx] = setConstant(n.value)
+			e.bytecode[i+selK] = int16(n.selKey)
 		case operator, fastOperator:
-			third = setOperator(n.value.(string), n.operator)
+			e.bytecode[i+flag] = n.flag
+			e.bytecode[i+rIdx] = setOperator(n.value.(string), n.operator)
+			e.bytecode[i+cIdx] = int16(n.childIdx * align)
+			e.bytecode[i+cCnt] = int16(n.childCnt)
 		}
 
-		i = i * 4
-		e.bytecode[i+0] = int16(n.childCnt)<<8 | n.flag // child count and flag
-		e.bytecode[i+1] = int16(n.childIdx)             // child index
-		e.bytecode[i+2] = third                         // index of constants, index of operator, selectorKey
-		e.bytecode[i+3] = forth                         // select key
+		//e.bytecode[i+0] = int16(n.childCnt)<<8 | n.flag // child count and flag
+		//e.bytecode[i+1] = int16(n.childIdx)             // child index
+		//e.bytecode[i+2] = third                         // index of constants, index of operator, selectorKey
+		//e.bytecode[i+3] = forth                         // select key
 	}
 }
 

--- a/engine.go
+++ b/engine.go
@@ -35,6 +35,15 @@ const (
 	scIfTrue  = int16(0b010000)
 )
 
+const (
+	align = 4
+	flag  = 0
+	rIdx  = 1
+	selK  = 2
+	cIdx  = 2
+	cCnt  = 3
+)
+
 type node struct {
 	flag     int16
 	idx      int
@@ -100,13 +109,13 @@ func (e *Expr) EvalBool(ctx *Ctx) (bool, error) {
 func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 	var (
 		size   = e.maxStackSize
-		maxIdx = -1
+		maxIdx = int16(-1)
 
-		sf    []int // stack frame
-		sfTop = -1
+		sf    []int16 // stack frame
+		sfTop = int16(-1)
 
 		os    []Value // operand stack
-		osTop = -1
+		osTop = int16(-1)
 
 		scTriggered bool
 
@@ -119,21 +128,20 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 	switch {
 	case size <= 4:
 		os = make([]Value, 4)
-		sf = make([]int, 4)
+		sf = make([]int16, 4)
 	case size <= 8:
 		os = make([]Value, 8)
-		sf = make([]int, 8)
+		sf = make([]int16, 8)
 	case size <= 16:
 		os = make([]Value, 16)
-		sf = make([]int, 16)
+		sf = make([]int16, 16)
 	default:
 		os = make([]Value, size)
-		sf = make([]int, size)
+		sf = make([]int16, size)
 	}
 
 	var (
-		curt    int
-		curtIdx int // index in bytecode
+		curt int16
 
 		res Value // result of current stack frame
 		err error
@@ -143,56 +151,54 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 	)
 
 	// push the root node to the stack frame
-	sf[sfTop+1], sfTop = 0, sfTop+1
+	//sf[sfTop+1], sfTop = 0, sfTop+1
+	sfTop = 0
 
 	for sfTop != -1 { // while stack frame is not empty
 		curt, sfTop = sf[sfTop], sfTop-1
-		curtIdx = curt * 4
 
-		switch bytecode[curtIdx] & nodeTypeMask {
+		switch bytecode[curt] & nodeTypeMask {
 		case fastOperator:
-			cnt := int(bytecode[curtIdx] >> 8)
-			childIdx := int(bytecode[curtIdx+1])
-			if cnt == 2 {
-				param2[0], err = e.getNodeValue(ctx, childIdx)
+			childIdx := bytecode[curt+cIdx]
+			res = constants[bytecode[childIdx+rIdx]]
+			if bytecode[childIdx]&nodeTypeMask == selector {
+				res, err = ctx.Get(SelectorKey(bytecode[childIdx+selK]), res.(string))
 				if err != nil {
 					return nil, err
-				}
-				param2[1], err = e.getNodeValue(ctx, childIdx+1)
-				if err != nil {
-					return nil, err
-				}
-				param = param2[:]
-			} else {
-				param = make([]Value, cnt)
-				for i := 0; i < cnt; i++ {
-					param[i], err = e.getNodeValue(ctx, childIdx+i)
-					if err != nil {
-						return nil, err
-					}
 				}
 			}
 
-			res, err = operators[int(bytecode[curtIdx+2])](ctx, param)
+			param2[0] = res
+			res = constants[bytecode[childIdx+align+rIdx]]
+			if bytecode[childIdx+align]&nodeTypeMask == selector {
+				res, err = ctx.Get(SelectorKey(bytecode[childIdx+align+selK]), res.(string))
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			param2[1] = res
+			param = param2[:]
+			res, err = operators[bytecode[curt+rIdx]](ctx, param)
 			if err != nil {
 				return nil, fmt.Errorf("operator execution error, operator: %v, error: %w", curt, err)
 			}
 		case operator:
-			cnt := int(bytecode[curtIdx] >> 8)
+			cnt := bytecode[curt+cCnt]
 			if curt > maxIdx {
 				// the node has never been visited before
 				maxIdx = curt
 				sf[sfTop+1], sfTop = curt, sfTop+1
-				childIdx := int(bytecode[curtIdx+1])
+				childIdx := bytecode[curt+cIdx]
 				// push child nodes into the stack frame
 				// the back nodes is on top
 				if cnt == 2 {
-					sf[sfTop+1], sfTop = childIdx+1, sfTop+1
+					sf[sfTop+1], sfTop = childIdx+align, sfTop+1
 					sf[sfTop+1], sfTop = childIdx, sfTop+1
 				} else {
 					sfTop = sfTop + cnt
-					for i := 0; i < cnt; i++ {
-						sf[sfTop-i] = childIdx + i
+					for i := int16(0); i < cnt; i++ {
+						sf[sfTop-i] = childIdx + i*align
 					}
 				}
 				continue
@@ -209,24 +215,23 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 				copy(param, os[osTop+1:])
 			}
 
-			res, err = operators[int(bytecode[curtIdx+2])](ctx, param)
+			res, err = operators[bytecode[curt+rIdx]](ctx, param)
 			if err != nil {
 				return nil, fmt.Errorf("operator execution error, operator: %v, error: %w", curt, err)
 			}
 		case selector:
-			res, err = ctx.Get(SelectorKey(e.bytecode[curtIdx+3]), "")
+			res, err = ctx.Get(SelectorKey(bytecode[curt+selK]), constants[bytecode[curt+rIdx]].(string))
 			if err != nil {
 				return nil, err
 			}
 		case constant:
-			res = constants[int(bytecode[curtIdx+2])]
+			res = constants[bytecode[curt+rIdx]]
 		case cond:
-			childIdx := int(bytecode[curtIdx+1])
+			childIdx := bytecode[curt+cIdx]
 			if curt > maxIdx {
-				cnt := int(bytecode[curtIdx] >> 8)
 				maxIdx = curt
 				// push the end node to the stack frame
-				sf[sfTop+1], sfTop = childIdx+cnt-1, sfTop+1
+				sf[sfTop+1], sfTop = childIdx+align*3, sfTop+1
 				sf[sfTop+1], sfTop = curt, sfTop+1
 				sf[sfTop+1], sfTop = childIdx, sfTop+1
 			} else {
@@ -243,11 +248,11 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 			}
 			continue
 		case end:
-			maxIdx = e.parentIdx[curt]
+			maxIdx = int16(e.parentIdx[curt])
 			res, osTop = os[osTop], osTop-1
 		default:
 			// only debug node will enter this branch
-			offset := len(e.nodes) / 2
+			offset := int16(len(e.nodes) / 2)
 			debugStackFrame(sf, sfTop, offset)
 
 			// push the real node to print stacks
@@ -255,25 +260,25 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 
 			e.printStacks(scTriggered, maxIdx, os, osTop, sf, sfTop)
 			scTriggered = false
+			//_ = scTriggered
 			continue
 		}
 
 		// short circuit
 		if b, ok := res.(bool); ok {
-			flag := bytecode[curtIdx] & scMask
-			for (!b && flag&scIfFalse == scIfFalse) ||
-				(b && flag&scIfTrue == scIfTrue) {
-
-				curt = e.scIdx[curt]
-				if curt == 0 {
+			f := bytecode[curt] & scMask
+			for (!b && f&scIfFalse == scIfFalse) ||
+				(b && f&scIfTrue == scIfTrue) {
+				scIdx := int16(e.scIdx[curt>>2])
+				if scIdx == 0 {
 					return res, nil
 				}
 				scTriggered = true
 
-				maxIdx = curt
-				sfTop = e.sfSize[curt] - 2
-				osTop = e.osSize[curt] - 1
-				flag = bytecode[curt<<2] & scMask
+				maxIdx = scIdx << 2
+				sfTop = int16(e.sfSize[scIdx]) - 2
+				osTop = int16(e.osSize[scIdx]) - 1
+				f = bytecode[maxIdx] & scMask
 			}
 		}
 
@@ -348,22 +353,22 @@ func getSelectorValue(ctx *Ctx, n *node) (res Value, err error) {
 	}
 }
 
-func debugStackFrame(sf []int, sfTop, offset int) {
+func debugStackFrame(sf []int16, sfTop, offset int16) {
 	// replace with debug node
-	for i := 0; i < sfTop; i++ {
+	for i := int16(0); i < sfTop; i++ {
 		if sf[i] >= offset {
 			sf[i] -= offset
 		}
 	}
 }
 
-func (e *Expr) printStacks(scTriggered bool, maxIdx int, os []Value, osTop int, sf []int, sfTop int) {
+func (e *Expr) printStacks(scTriggered bool, maxIdx int16, os []Value, osTop int16, sf []int16, sfTop int16) {
 	if scTriggered {
 		fmt.Printf("short circuit triggered\n\n")
 	}
 	var sb strings.Builder
 
-	offset := len(e.nodes) / 2
+	offset := int16(len(e.nodes) / 2)
 
 	fmt.Printf("maxIdx:%d, sfTop:%d, osTop:%d\n", maxIdx-offset, sfTop, osTop)
 	sb.WriteString(fmt.Sprintf("%15s", "Stack Frame: "))

--- a/engine.go
+++ b/engine.go
@@ -42,6 +42,7 @@ const (
 	rIdx = 1
 	selK = 2
 	cIdx = 2
+	pIdx = 2
 	cCnt = 3
 
 	fSfTop = 4
@@ -247,14 +248,14 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 					return nil, fmt.Errorf("eval error, result type of if condition should be bool, got: [%v]", res)
 				}
 				if condRes {
-					sf[sfTop+1], sfTop = childIdx+1, sfTop+1
+					sf[sfTop+1], sfTop = childIdx+align, sfTop+1
 				} else {
-					sf[sfTop+1], sfTop = childIdx+2, sfTop+1
+					sf[sfTop+1], sfTop = childIdx+align<<1, sfTop+1
 				}
 			}
 			continue
 		case end:
-			maxIdx = int16(e.parentIdx[curt])
+			maxIdx = bytecode[curt+pIdx]
 			res, osTop = os[osTop], osTop-1
 		default:
 			// only debug node will enter this branch
@@ -275,6 +276,7 @@ func (e *Expr) Eval(ctx *Ctx) (Value, error) {
 			f := bytecode[curt]
 			if (!b && f&scIfFalse == scIfFalse) ||
 				(b && f&scIfTrue == scIfTrue) {
+				scTriggered = true
 
 				if !b {
 					sfTop = bytecode[curt+fSfTop]

--- a/engine_test.go
+++ b/engine_test.go
@@ -12,8 +12,42 @@ import (
 	"time"
 )
 
+func TestDebug(t *testing.T) {
+	cc := NewCompileConfig()
+
+	ctx := NewCtxWithMap(cc, ToValueMap(map[string]interface{}{
+		"Origin":  "MOW",
+		"Country": "RU",
+		"Adults":  1,
+		"Value":   100,
+	}))
+
+	s := `
+(and
+  (|
+    (eq Origin "MOW")
+    (= Country "RU"))
+  (or
+    (>= Value 100)
+    (= Adults 1)))
+`
+
+	expr, err := Compile(cc, s)
+
+	assertNil(t, err)
+
+	fmt.Println(Dump(expr))
+	fmt.Println(PrintExpr(expr))
+
+	res, err := expr.Eval(ctx)
+
+	assertNil(t, err)
+
+	assertEquals(t, res, true)
+}
+
 func TestDebugCases(t *testing.T) {
-	const onlyAllowListCases = false
+	const onlyAllowListCases = true
 
 	type runThis string
 	const ________RunThisOne________ runThis = "________RunThisOne________"
@@ -35,7 +69,6 @@ func TestDebugCases(t *testing.T) {
 		run           runThis
 	}{
 		{
-			run:           ________RunThisOne________,
 			want:          true,
 			optimizeLevel: disable,
 			s: `
@@ -303,6 +336,7 @@ func TestDebugCases(t *testing.T) {
     (= 0 0)))`,
 		},
 		{
+			run:  ________RunThisOne________,
 			want: true,
 			s: `
 (and
@@ -455,7 +489,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 3000000
+		size          = 10000
 		level         = 53
 		step          = size / 100
 		showSample    = false

--- a/engine_test.go
+++ b/engine_test.go
@@ -69,7 +69,6 @@ func TestDebugCases(t *testing.T) {
 		run           runThis
 	}{
 		{
-			run:           ________RunThisOne________,
 			want:          true,
 			optimizeLevel: disable,
 			s:             `(not F)`,
@@ -133,6 +132,7 @@ func TestDebugCases(t *testing.T) {
 			},
 		},
 		{
+			run:           ________RunThisOne________,
 			want:          true,
 			optimizeLevel: disable,
 			s: `
@@ -410,7 +410,7 @@ func TestDebugCases(t *testing.T) {
 			continue
 		}
 
-		options := []CompileOption{EnableDebug}
+		options := []CompileOption{}
 		switch c.optimizeLevel {
 		case all:
 			options = append(options, Optimizations(true))
@@ -505,7 +505,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 10000
+		size          = 10000000
 		level         = 23
 		step          = size / 100
 		showSample    = false
@@ -570,7 +570,7 @@ func TestRandomExpressions(t *testing.T) {
 				}
 
 				if v&0b010 != 0 {
-					//options = append(options, EnableCondition)
+					options = append(options, EnableCondition)
 				}
 
 				if v&0b100 != 0 {

--- a/engine_test.go
+++ b/engine_test.go
@@ -69,6 +69,28 @@ func TestDebugCases(t *testing.T) {
 		run           runThis
 	}{
 		{
+			run:           ________RunThisOne________,
+			want:          true,
+			optimizeLevel: disable,
+			s:             `(not F)`,
+			valMap: map[string]Value{
+				"F": false,
+			},
+		},
+		{
+			want:          true,
+			optimizeLevel: disable,
+			s: `
+(eq F
+  (!= 0 0)
+  (or F
+    (!= 0 0)))`,
+			valMap: map[string]Value{
+				"F": false,
+			},
+		},
+
+		{
 			want:          true,
 			optimizeLevel: disable,
 			s: `
@@ -289,7 +311,6 @@ func TestDebugCases(t *testing.T) {
 		},
 
 		{
-
 			want:          true,
 			optimizeLevel: onlyFast,
 			s: `
@@ -302,7 +323,6 @@ func TestDebugCases(t *testing.T) {
     (= 0 0)))`,
 		},
 		{
-
 			want:          true,
 			optimizeLevel: onlyFast,
 			s: `
@@ -318,8 +338,6 @@ func TestDebugCases(t *testing.T) {
       (= 0 0))))`,
 		},
 		{
-
-			want:          true,
 			optimizeLevel: onlyFast,
 			s: `
 (and
@@ -336,7 +354,6 @@ func TestDebugCases(t *testing.T) {
     (= 0 0)))`,
 		},
 		{
-			run:  ________RunThisOne________,
 			want: true,
 			s: `
 (and
@@ -371,7 +388,6 @@ func TestDebugCases(t *testing.T) {
 			fields: []string{"scIdx", "scVal", "pIdx"},
 		},
 		{
-
 			want: false,
 			s: `
 ;;;;optimize:false
@@ -390,7 +406,7 @@ func TestDebugCases(t *testing.T) {
 	}
 
 	for _, c := range cs {
-		if onlyAllowListCases && c.run != ________RunThisOne________ {
+		if onlyAllowListCases && c.run != "________RunThisOne________" {
 			continue
 		}
 
@@ -490,7 +506,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 func TestRandomExpressions(t *testing.T) {
 	const (
 		size          = 10000
-		level         = 53
+		level         = 23
 		step          = size / 100
 		showSample    = false
 		printProgress = true
@@ -554,7 +570,7 @@ func TestRandomExpressions(t *testing.T) {
 				}
 
 				if v&0b010 != 0 {
-					options = append(options, EnableCondition)
+					//options = append(options, EnableCondition)
 				}
 
 				if v&0b100 != 0 {

--- a/operator.go
+++ b/operator.go
@@ -555,6 +555,7 @@ func ParamsCountError(opName string, want, got int) error {
 }
 
 func ParamTypeError(opName string, want string, got Value) error {
+	panic("v")
 	return fmt.Errorf("unexpected param type, operator: %s, expected: %s, got: %+v", opName, want, got)
 }
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type verifyNode struct {
-	tpy       uint8
+	tpy       int16
 	data      Value
 	cost      int
 	selectKey SelectorKey

--- a/util.go
+++ b/util.go
@@ -462,16 +462,20 @@ func max(a, b int) int {
 func PrintExpr(expr *Expr, fields ...string) string {
 	type fetcher func(e *Expr, i int) Value
 	const (
-		idx   = "idx"
-		node  = "node"
-		pIdx  = "pIdx"
-		flag  = "flag"
-		cCnt  = "cCnt"
-		cIdx  = "cIdx"
-		scIdx = "scIdx"
-		scVal = "scVal"
-		sfTop = "sfTop"
-		osTop = "osTop"
+		idx     = "idx"
+		node    = "node"
+		pIdx    = "pIdx"
+		flag    = "flag"
+		cCnt    = "cCnt"
+		cIdx    = "cIdx"
+		scIdx   = "scIdx"
+		scVal   = "scVal"
+		sfTop   = "sfTop"
+		osTop   = "osTop"
+		fOsTop_ = "fOsTp"
+		fSfTop_ = "fSfTp"
+		tOsTop_ = "tOsTp"
+		tSfTop_ = "tSfTp"
 	)
 
 	fetchers := map[string]fetcher{
@@ -531,9 +535,21 @@ func PrintExpr(expr *Expr, fields ...string) string {
 		osTop: func(e *Expr, i int) Value {
 			return e.osSize[i] - 1
 		},
+		fSfTop_: func(e *Expr, i int) Value {
+			return e.bytecode[i*align+fSfTop]
+		},
+		fOsTop_: func(e *Expr, i int) Value {
+			return e.bytecode[i*align+fOsTop]
+		},
+		tSfTop_: func(e *Expr, i int) Value {
+			return e.bytecode[i*align+tSfTop]
+		},
+		tOsTop_: func(e *Expr, i int) Value {
+			return e.bytecode[i*align+tOsTop]
+		},
 	}
 
-	var allFields = []string{idx, node, pIdx, flag, cCnt, cIdx, scIdx, scVal, sfTop, osTop}
+	var allFields = []string{idx, node, pIdx, flag, cCnt, cIdx, scIdx, scVal, sfTop, osTop, tSfTop_, tOsTop_, fSfTop_, fOsTop_}
 
 	if len(fields) == 0 {
 		fields = allFields


### PR DESCRIPTION
## Summary

## Test Plan
- [ ] Unit test passed
```
❯ go test

```

- [X] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/larry618/eval_bench
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16     	41244609	        77.11 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16      	45792898	        77.74 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16    	45724270	        77.53 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16     	45304260	        77.71 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/larry618/eval_bench	14.626s
```

- [X] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|    110277|    100000|      7489|       388|    1.792s|
|       2 %|       2 %|    222400|    200000|     10000|     10000|    2.215s|
|       3 %|       3 %|    309449|    300000|      6728|       321|    1.764s|
|       4 %|       4 %|    411369|    400000|      8605|       364|    2.308s|
|       5 %|       5 %|    511607|    500000|      9189|        18|    2.532s|
|       6 %|       6 %|    603887|    600000|      1300|       187|    2.324s|
|       7 %|       7 %|    707500|    700000|      5098|         2|    2.279s|
|       8 %|       8 %|    812933|    800000|      7921|      2612|    2.329s|
|       9 %|       9 %|    906383|    900000|      3666|       317|    2.344s|
|      10 %|      10 %|   1009211|   1000000|      6753|        58|    2.393s|
|      11 %|      11 %|   1111942|   1100000|      9367|       175|    2.191s|
|      12 %|      12 %|   1212320|   1200000|      8637|      1283|    2.467s|
|      13 %|      13 %|   1311230|   1300000|      8504|       326|     2.33s|
|      14 %|      14 %|   1410075|   1400000|      6984|       691|    2.434s|
|      15 %|      15 %|   1510107|   1500000|      7654|        56|    2.666s|
|      16 %|      16 %|   1613503|   1600000|      9828|      1276|    2.455s|
|      17 %|      17 %|   1712323|   1700000|      9389|       534|    2.293s|
|      18 %|      18 %|   1804158|   1800000|      1118|       640|    2.517s|
|      19 %|      19 %|   1912668|   1900000|      9579|       689|    2.642s|
|      20 %|      20 %|   2011252|   2000000|      8616|       236|    2.492s|
|      21 %|      21 %|   2108483|   2100000|      5996|        87|    2.492s|
|      22 %|      22 %|   2211745|   2200000|      9322|        23|    2.585s|
|      23 %|      23 %|   2308236|   2300000|      5280|       556|    2.513s|
|      24 %|      24 %|   2405612|   2400000|      3029|       185|    2.685s|
|      25 %|      25 %|   2511001|   2500000|      8584|        17|    2.403s|
|      26 %|      26 %|   2612730|   2600000|      9747|       583|    2.494s|
|      27 %|      27 %|   2711629|   2700000|      7317|      1912|    2.403s|
|      28 %|      28 %|   2808242|   2800000|      5740|       102|    2.434s|
|      29 %|      29 %|   2906882|   2900000|      4422|        60|    2.567s|
|      30 %|      30 %|   3009431|   3000000|      4883|      2148|    2.627s|
|      31 %|      31 %|   3106366|   3100000|      3182|       784|    2.328s|
|      32 %|      32 %|   3206442|   3200000|      2950|      1092|    2.329s|
|      33 %|      33 %|   3302950|   3300000|       412|       138|    2.385s|
|      34 %|      34 %|   3408363|   3400000|      5362|       602|    2.469s|
|      35 %|      35 %|   3505567|   3500000|      2956|       211|    2.517s|
|      36 %|      36 %|   3606940|   3600000|      4528|        12|    2.473s|
|      37 %|      37 %|   3708077|   3700000|      5663|        14|    2.544s|
|      38 %|      38 %|   3803596|   3800000|       402|       794|    2.427s|
|      39 %|      39 %|   3911215|   3900000|      8811|         4|    2.655s|
|      40 %|      40 %|   4003888|   4000000|       525|       964|    2.417s|
|      41 %|      41 %|   4116895|   4100000|      9899|      4596|    2.412s|
|      42 %|      42 %|   4211883|   4200000|      9479|         4|    2.197s|
|      43 %|      43 %|   4306862|   4300000|      4395|        67|    2.289s|
|      44 %|      44 %|   4411983|   4400000|      9340|       243|    2.331s|
|      45 %|      45 %|   4503711|   4500000|      1091|       220|    2.365s|
|      46 %|      46 %|   4622400|   4600000|     10000|     10000|    2.836s|
|      47 %|      47 %|   4710679|   4700000|      8110|       169|    2.133s|
|      48 %|      48 %|   4809282|   4800000|      6877|         5|    2.195s|
|      49 %|      49 %|   4904257|   4900000|      1786|        71|    2.382s|
|      50 %|      50 %|   5003874|   5000000|       836|       638|     2.42s|
|      51 %|      51 %|   5110220|   5100000|      7378|       442|    2.718s|
|      52 %|      52 %|   5205790|   5200000|      3030|       360|    2.523s|
|      53 %|      53 %|   5310353|   5300000|      7068|       885|    2.614s|
|      54 %|      54 %|   5407307|   5400000|      4478|       429|     2.69s|
|      55 %|      55 %|   5513038|   5500000|      9680|       958|     2.67s|
|      56 %|      56 %|   5604377|   5600000|       778|      1199|    2.575s|
|      57 %|      57 %|   5705064|   5700000|      2504|       160|    2.825s|
|      58 %|      58 %|   5811646|   5800000|      8889|       357|    2.633s|
|      59 %|      59 %|   5912275|   5900000|      9691|       184|    2.703s|
|      60 %|      60 %|   6009871|   6000000|      7330|       141|    2.607s|
|      61 %|      61 %|   6110627|   6100000|      8221|         6|    2.873s|
|      62 %|      62 %|   6211151|   6200000|      8683|        68|    2.698s|
|      63 %|      63 %|   6312444|   6300000|      9416|       628|    2.687s|
|      64 %|      64 %|   6411668|   6400000|      8186|      1082|    2.666s|
|      65 %|      65 %|   6522400|   6500000|     10000|     10000|    2.897s|
|      66 %|      66 %|   6612398|   6600000|     10000|         3|    2.312s|
|      67 %|      67 %|   6711082|   6700000|      8634|        48|     2.51s|
|      68 %|      68 %|   6806523|   6800000|      3835|       288|    2.496s|
|      69 %|      69 %|   6906419|   6900000|      3892|       127|     2.53s|
|      70 %|      70 %|   7008570|   7000000|      5662|       508|    2.606s|
|      71 %|      71 %|   7110340|   7100000|      7820|       120|     2.55s|
|      72 %|      72 %|   7205394|   7200000|      2938|        57|    2.688s|
|      73 %|      73 %|   7304317|   7300000|       897|      1020|    2.572s|
|      74 %|      74 %|   7407732|   7400000|      4527|       805|    2.439s|
|      75 %|      75 %|   7510617|   7500000|      7240|       977|    2.571s|
|      76 %|      76 %|   7609934|   7600000|      7380|       154|    2.484s|
|      77 %|      77 %|   7710652|   7700000|      7381|       871|    2.582s|
|      78 %|      78 %|   7806363|   7800000|      3416|       547|    2.575s|
|      79 %|      79 %|   7914072|   7900000|      9929|      1743|      2.6s|
|      80 %|      80 %|   8009360|   8000000|      6577|       383|    2.608s|
|      81 %|      81 %|   8109338|   8100000|      6793|       145|    2.667s|
|      82 %|      82 %|   8212283|   8200000|      9788|        95|    2.599s|
|      83 %|      83 %|   8311108|   8300000|      8596|       112|    2.464s|
|      84 %|      84 %|   8403230|   8400000|         4|       826|    2.579s|
|      85 %|      85 %|   8512070|   8500000|      9667|         3|    2.617s|
|      86 %|      86 %|   8604469|   8600000|      1668|       402|    2.607s|
|      87 %|      87 %|   8711523|   8700000|      9065|        58|    2.607s|
|      88 %|      88 %|   8811562|   8800000|      9101|        61|    2.542s|
|      89 %|      89 %|   8912236|   8900000|      9743|        93|    2.431s|
|      90 %|      90 %|   9012544|   9000000|      9913|       231|    2.804s|
|      91 %|      91 %|   9109547|   9100000|      6148|       999|    2.473s|
|      92 %|      92 %|   9210632|   9200000|      8151|        81|    2.701s|
|      93 %|      93 %|   9312120|   9300000|      8950|       772|    2.688s|
|      94 %|      94 %|   9412286|   9400000|      9018|       868|     2.77s|
|      95 %|      95 %|   9509283|   9500000|      6352|       531|    2.887s|
|      96 %|      96 %|   9612171|   9600000|      9417|       354|    2.666s|
|      97 %|      97 %|   9710587|   9700000|      8140|        47|    2.625s|
|      98 %|      98 %|   9813889|   9800000|      8958|      2531|    2.773s|
|      99 %|      99 %|   9913549|   9900000|      8742|      2407|    2.799s|
|     100 %|     100 %|  10000000|  10000000|         0|         0|     2.72s|
PASS
ok  	github.com/larry618/eval	252.496s
```

## Reviewers
@larry618