### PR TITLE
[engine] improve usability

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -62,6 +62,14 @@ var (
 			}
 		}
 	}
+
+	RegisterSelKeys = func(vals map[string]interface{}) CompileOption {
+		return func(c *CompileConfig) {
+			for s := range vals {
+				GetOrRegisterKey(c, s)
+			}
+		}
+	}
 )
 
 func NewCompileConfig(opts ...CompileOption) *CompileConfig {

--- a/engine_test.go
+++ b/engine_test.go
@@ -28,7 +28,7 @@ func TestDebugCases(t *testing.T) {
 	cs := []struct {
 		name          string
 		s             string
-		valMap        map[string]Value
+		valMap        map[string]interface{}
 		optimizeLevel optimizeLevel // default: all
 		fields        []string
 		want          Value
@@ -46,7 +46,7 @@ func TestDebugCases(t *testing.T) {
       (= 4 4))
     (= 5 5)
     (= 6 6)))`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"T": true,
 				"F": false,
 			},
@@ -71,7 +71,7 @@ func TestDebugCases(t *testing.T) {
   (not F)
   (and
     (!= 3 4) T1 T2))`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"T1": true,
 				"T2": true,
 				"F":  false,
@@ -84,7 +84,7 @@ func TestDebugCases(t *testing.T) {
 (eq
   (if T F T)
   (not T))`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"T": true,
 				"F": false,
 			},
@@ -97,7 +97,7 @@ func TestDebugCases(t *testing.T) {
    (- 2 v3) (/ 6 3) 4)
  (* 5 6 7)
 )`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"v3": 3,
 			},
 		},
@@ -106,7 +106,7 @@ func TestDebugCases(t *testing.T) {
 			want:          int64(-1),
 			optimizeLevel: disable,
 			s:             "(if less -1 1)",
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"less": true,
 			},
 		},
@@ -128,7 +128,7 @@ func TestDebugCases(t *testing.T) {
       (= 0 0))
     (= 0 0)
     (= 0 0)))`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"T": true,
 				"F": false,
 			},
@@ -138,7 +138,7 @@ func TestDebugCases(t *testing.T) {
 			want:          int64(1),
 			optimizeLevel: disable,
 			s:             `(if T 1 0)`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"T": true,
 				"F": false,
 			},
@@ -152,7 +152,7 @@ func TestDebugCases(t *testing.T) {
   (if T F T)
   (or T
     (!= 0 0)))`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"T": true,
 				"F": false,
 			},
@@ -165,7 +165,7 @@ func TestDebugCases(t *testing.T) {
   (or
     (eq 1 2) T)
   (= 3 4))`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"T": true,
 				"F": false,
 			},
@@ -180,7 +180,7 @@ func TestDebugCases(t *testing.T) {
   (not
     (= 0 0))
   (!= 0 0))`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"T": true,
 				"F": false,
 			},
@@ -194,7 +194,7 @@ func TestDebugCases(t *testing.T) {
   (not F)
   (and
     (!= 3 4) T1 T2))`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"T1": true,
 				"T2": true,
 				"F":  false,
@@ -226,7 +226,7 @@ func TestDebugCases(t *testing.T) {
     (!= 0 0)) 
   true)
 `,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"select_true_1":  true,
 				"select_false_1": false,
 				"select_false":   false,
@@ -312,7 +312,7 @@ func TestDebugCases(t *testing.T) {
   (or
     (>= Value 100)
     (<= Adults 1)))`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"Origin":  "MOW",
 				"Country": "RU",
 				"Value":   100,
@@ -328,7 +328,7 @@ func TestDebugCases(t *testing.T) {
 			  (= Country "RU")
 			  (>= Value 100)
 			  (= Adults 1))`,
-			valMap: map[string]Value{
+			valMap: map[string]interface{}{
 				"Origin":  "MOW",
 				"Country": "RU",
 				"Value":   100,
@@ -397,7 +397,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 		expr   string
 		want   Value
 		errMsg string
-		vals   map[string]Value
+		vals   map[string]interface{}
 	}{
 		{
 			expr:   `(< age 18)`,
@@ -407,7 +407,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 			want: false,
 			expr: `(< age 18)`,
 			cc:   NewCompileConfig(EnableStringSelectors),
-			vals: map[string]Value{
+			vals: map[string]interface{}{
 				"age": int64(20),
 			},
 		},
@@ -434,14 +434,14 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
  (* 5 -6 7)
 )`,
 			cc: NewCompileConfig(EnableStringSelectors),
-			vals: map[string]Value{
+			vals: map[string]interface{}{
 				"v3": int64(3),
 			},
 		},
 	}
 
 	for _, c := range testCases {
-		got, err := Eval(c.cc, c.expr, &Ctx{Selector: NewMapSelector(c.vals)})
+		got, err := Eval(c.expr, c.vals, c.cc)
 
 		if len(c.errMsg) != 0 {
 			assertErrStrContains(t, err, c.errMsg)
@@ -455,7 +455,7 @@ func TestEval_AllowUnknownSelector(t *testing.T) {
 
 func TestRandomExpressions(t *testing.T) {
 	const (
-		size          = 3000000
+		size          = 10000
 		level         = 53
 		step          = size / 100
 		showSample    = false
@@ -476,7 +476,7 @@ func TestRandomExpressions(t *testing.T) {
 		"select_false": SelectorKey(2),
 	}
 
-	valMap := map[string]Value{
+	valMap := map[string]interface{}{
 		"select_true":  true,
 		"select_false": false,
 	}
@@ -552,8 +552,7 @@ func TestRandomExpressions(t *testing.T) {
 				cc.CompileOptions[Reordering] = v&0b1 != 0
 				cc.CompileOptions[FastEvaluation] = v&0b10 != 0
 				cc.CompileOptions[ConstantFolding] = v&0b100 != 0
-				ctx := NewCtxWithMap(cc, valMap)
-				got, err := Eval(cc, expr.Expr, ctx)
+				got, err := Eval(expr.Expr, valMap, cc)
 
 				verifyChan <- execRes{
 					expr: expr,

--- a/operator_test.go
+++ b/operator_test.go
@@ -38,7 +38,7 @@ func TestRegisterOperator(t *testing.T) {
 	err := RegisterOperator(cc, "max", maxOp)
 	assertNil(t, err)
 
-	res, err := Eval(cc, `(max 1 5 3)`, &Ctx{})
+	res, err := Eval(`(max 1 5 3)`, nil, cc)
 	assertNil(t, err)
 	assertEquals(t, res, int64(5))
 

--- a/util.go
+++ b/util.go
@@ -48,7 +48,7 @@ var (
 		}
 	}
 
-	GenSelectors = func(m map[string]Value) GenExprOption {
+	GenSelectors = func(m map[string]interface{}) GenExprOption {
 		return func(c *GenExprConfig) {
 			var ns []GenExprResult
 			var bs []GenExprResult
@@ -189,7 +189,7 @@ func GenerateRandomExpr(level int, random *rand.Rand, opts ...GenExprOption) Gen
 	return helper(c.GenType, level)
 }
 
-func GenerateTestCase(res GenExprResult, valMap map[string]Value) string {
+func GenerateTestCase(res GenExprResult, valMap map[string]interface{}) string {
 	var valStr = func(val Value) string {
 		switch v := val.(type) {
 		case bool:
@@ -223,7 +223,7 @@ func GenerateTestCase(res GenExprResult, valMap map[string]Value) string {
 	}
 
 	if valMap != nil {
-		mapStr.WriteString("map[string]Value{\n")
+		mapStr.WriteString("map[string]interface{}{\n")
 		for key, val := range valMap {
 			mapStr.WriteString(strings.Repeat(space, tab*4))
 			mapStr.WriteString(fmt.Sprintf(`"%s": `, key))

--- a/util_test.go
+++ b/util_test.go
@@ -159,7 +159,7 @@ func TestGenerateRandomExpr_Bool(t *testing.T) {
 			ConstantFolding: false,
 		},
 	}
-	valMap := map[string]Value{
+	valMap := map[string]interface{}{
 		//"select_true":    true,
 		//"select_false":   false,
 		//"select_true_1":  true,
@@ -167,12 +167,11 @@ func TestGenerateRandomExpr_Bool(t *testing.T) {
 		"T": true,
 		"F": false,
 	}
-	ctx := NewCtxWithMap(cc, valMap)
 
 	for i := 1; i < size; i++ {
 		expr := GenerateRandomExpr(i, r, GenType(Bool), EnableSelector, EnableCondition, GenSelectors(valMap))
 
-		got, err := Eval(cc, expr.Expr, ctx)
+		got, err := Eval(expr.Expr, valMap, cc)
 		if err != nil {
 			fmt.Println(GenerateTestCase(expr, valMap))
 			t.Fatalf("assertNil failed, got: %+v\n", err)
@@ -194,7 +193,7 @@ func TestGenerateRandomExpr_Number(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	keyMap := make(map[string]SelectorKey, selectorSize)
-	valMap := make(map[string]Value, selectorSize)
+	valMap := make(map[string]interface{}, selectorSize)
 	for i := 0; i < selectorSize; i++ {
 		v := r.Intn(200) - 100
 		var k string
@@ -213,14 +212,13 @@ func TestGenerateRandomExpr_Number(t *testing.T) {
 			ConstantFolding: false,
 		},
 	}
-	ctx := NewCtxWithMap(cc, valMap)
 
 	for i := 0; i < size; i++ {
 		expr := GenerateRandomExpr(size, r, GenType(Number), EnableCondition, EnableSelector, GenSelectors(valMap))
 		//fmt.Println(IndentByParentheses(expr.Expr))
 		//fmt.Println(expr.Res)
 
-		got, err := Eval(cc, expr.Expr, ctx)
+		got, err := Eval(expr.Expr, valMap, cc)
 		if err != nil {
 			fmt.Println(GenerateTestCase(expr, valMap))
 			t.Fatalf("assertNil failed, got: %+v\n", err)
@@ -237,7 +235,7 @@ func TestGenerateTestCase(t *testing.T) {
 	testCases := []struct {
 		expr GenExprResult
 		want string
-		vals map[string]Value
+		vals map[string]interface{}
 	}{
 		{
 			expr: GenExprResult{
@@ -252,11 +250,11 @@ func TestGenerateTestCase(t *testing.T) {
 (not
   (eq select_false select_false
     (!= 0 0)))` + "`" + `,
-            valMap: map[string]Value{
+            valMap: map[string]interface{}{
                 "select_false": false,
             },
         },`,
-			vals: map[string]Value{
+			vals: map[string]interface{}{
 				"select_false": false,
 			},
 		},
@@ -270,11 +268,11 @@ func TestGenerateTestCase(t *testing.T) {
             want:          int64(-1),
             optimizeLevel: disable,
             s:             "(if less -1 1)",
-            valMap: map[string]Value{
+            valMap: map[string]interface{}{
                 "less": true,
             },
         },`,
-			vals: map[string]Value{
+			vals: map[string]interface{}{
 				"less": true,
 			},
 		},
@@ -303,11 +301,11 @@ func TestGenerateTestCase(t *testing.T) {
             s: ` + "`" + `
 (if
   (< age 18) "Child" "Adult")` + "`" + `,
-            valMap: map[string]Value{
+            valMap: map[string]interface{}{
                 "age": int64(18),
             },
         },`,
-			vals: map[string]Value{
+			vals: map[string]interface{}{
 				"age": int64(18),
 			},
 		},


### PR DESCRIPTION
## Summary
This PR improves the usability, make `Eval` easy to use.
```go
func ExampleEval() {
	output, err := evalloc.Eval(`(+ 1 v1)`, map[string]interface{}{
		"v1": 1,
	})
	if err != nil {
		fmt.Printf("err: %v", err)
		return
	}

	fmt.Printf("%v", output)

	// Output: 2
}
```


## Test Plan
- [X] Unit test passed
```
❯ go test
PASS
ok  	github.com/larry618/eval	1.849s
```

- [x] No degradation in performance
```
❯ go test -bench=BenchmarkEval -run=none -benchtime=3s -benchmem
goos: darwin
goarch: amd64
pkg: github.com/larry618/eval_lab/benchmark/local
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkEvalLocal-16     	39623710	        78.16 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain-16      	45869836	        76.30 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalLocal1-16    	43805353	        78.94 ns/op	      32 B/op	       1 allocs/op
BenchmarkEvalMain1-16     	44511973	        77.14 ns/op	      32 B/op	       1 allocs/op
PASS
ok  	github.com/larry618/eval_lab/benchmark/local	14.270s
```

- [x] Tested on over a million random expressions
```
❯ go test -run='TestRandomExpressions'
| gen progs|exec progs| gen count|exec count|  gen chan| exec chan|      time|
|----------|----------|----------|----------|----------|----------|----------|
|       1 %|       1 %|     36924|     30000|      4459|        65|    1.986s|
|       2 %|       2 %|     62763|     60000|       358|         5|    3.573s|
|       3 %|       3 %|     92958|     90000|       548|        10|    3.971s|
|       4 %|       4 %|    122628|    120000|         1|       227|    4.262s|
|       5 %|       5 %|    153749|    150000|       272|      1077|    4.201s|
|       6 %|       6 %|    182524|    180000|        98|        26|    3.947s|
|       7 %|       7 %|    214134|    210000|      1716|        18|    4.187s|
|       8 %|       8 %|    242471|    240000|        31|        40|     3.95s|
|       9 %|       9 %|    292400|    270000|     10000|     10000|    6.047s|
|      10 %|      10 %|    309022|    300000|      6381|       241|    2.544s|
|      11 %|      11 %|    335315|    330000|      2909|         6|    3.963s|
|      12 %|      12 %|    362988|    360000|       574|        14|    4.705s|
|      13 %|      13 %|    392444|    390000|        36|         8|    4.216s|
|      14 %|      14 %|    422511|    420000|         0|       113|    4.323s|
|      15 %|      15 %|    452657|    450000|         0|       259|    4.156s|
|      16 %|      16 %|    483538|    480000|      1134|         4|    4.282s|
|      17 %|      17 %|    512589|    510000|       133|        56|    4.412s|
|      18 %|      18 %|    542588|    540000|       176|        12|    4.367s|
|      19 %|      19 %|    572447|    570000|        25|        22|     4.45s|
|      20 %|      20 %|    602760|    600000|        24|       336|    4.677s|
|      21 %|      21 %|    632654|    630000|       242|        12|    4.428s|
|      22 %|      22 %|    662498|    660000|         0|       101|    4.442s|
|      23 %|      23 %|    692400|    690000|         0|         1|    4.508s|
|      24 %|      24 %|    722526|    720000|       116|        10|    4.513s|
|      25 %|      25 %|    752476|    750000|        27|        49|    4.612s|
|      26 %|      26 %|    782424|    780000|         2|        22|    4.864s|
|      27 %|      27 %|    812942|    810000|       508|        34|    5.622s|
|      28 %|      28 %|    842930|    840000|       492|        38|    4.635s|
|      29 %|      29 %|    872578|    870000|        46|       132|    4.442s|
|      30 %|      30 %|    902545|    900000|        23|       122|    4.293s|
|      31 %|      31 %|    932508|    930000|        96|        12|    4.563s|
|      32 %|      32 %|    962574|    960000|       135|        39|    4.426s|
|      33 %|      33 %|    992636|    990000|       132|       104|    4.873s|
|      34 %|      34 %|   1023146|   1020000|       623|       123|    4.772s|
|      35 %|      35 %|   1052518|   1050000|        35|        83|    4.759s|
|      36 %|      36 %|   1082778|   1080000|       261|       117|    4.637s|
|      37 %|      37 %|   1112510|   1110000|       109|         1|    4.434s|
|      38 %|      38 %|   1143312|   1140000|       876|        36|    4.736s|
|      39 %|      39 %|   1172564|   1170000|        65|        99|    4.285s|
|      40 %|      40 %|   1202539|   1200000|        79|        60|    4.664s|
|      41 %|      41 %|   1233251|   1230000|       745|       106|    4.614s|
|      42 %|      42 %|   1262563|   1260000|         7|       156|    4.654s|
|      43 %|      43 %|   1292827|   1290000|         0|       431|    4.505s|
|      44 %|      44 %|   1322607|   1320000|        18|       189|    4.249s|
|      45 %|      45 %|   1352432|   1350000|        32|         0|    4.352s|
|      46 %|      46 %|   1382521|   1380000|        95|        26|    4.339s|
|      47 %|      47 %|   1412638|   1410000|       110|       128|    4.348s|
|      48 %|      48 %|   1442764|   1440000|       306|        58|    4.311s|
|      49 %|      49 %|   1472779|   1470000|       214|       165|    4.341s|
|      50 %|      50 %|   1502438|   1500000|        16|        22|    4.323s|
|      51 %|      51 %|   1532582|   1530000|       165|        17|    4.331s|
|      52 %|      52 %|   1562523|   1560000|        95|        28|    4.503s|
|      53 %|      53 %|   1592524|   1590000|        36|        88|     4.42s|
|      54 %|      54 %|   1622487|   1620000|        19|        69|      4.4s|
|      55 %|      55 %|   1652525|   1650000|         3|       122|    4.385s|
|      56 %|      56 %|   1682463|   1680000|        44|        19|    4.366s|
|      57 %|      57 %|   1712580|   1710000|       152|        28|    4.545s|
|      58 %|      58 %|   1762400|   1740000|     10000|     10000|    6.587s|
|      59 %|      59 %|   1776235|   1770000|      3648|       187|    2.985s|
|      60 %|      60 %|   1802469|   1800000|        48|        21|    4.277s|
|      61 %|      61 %|   1833426|   1830000|      1016|        10|    4.595s|
|      62 %|      62 %|   1862472|   1860000|        55|        17|    4.857s|
|      63 %|      63 %|   1892412|   1890000|         0|        15|    4.568s|
|      64 %|      64 %|   1922571|   1920000|       127|        44|    4.529s|
|      65 %|      65 %|   1952391|   1950000|         0|         0|    4.559s|
|      66 %|      66 %|   1982881|   1980000|       424|        57|    4.666s|
|      67 %|      67 %|   2012564|   2010000|       119|        45|    4.567s|
|      68 %|      68 %|   2042497|   2040000|        91|         6|    4.422s|
|      69 %|      69 %|   2072664|   2070000|       215|        49|     4.41s|
|      70 %|      70 %|   2109597|   2100000|      7113|        84|    4.468s|
|      71 %|      71 %|   2132586|   2130000|       127|        60|    4.162s|
|      72 %|      72 %|   2163670|   2160000|      1135|       135|    4.377s|
|      73 %|      73 %|   2193114|   2190000|       672|        42|    4.342s|
|      74 %|      74 %|   2222660|   2220000|       223|        37|     4.43s|
|      75 %|      75 %|   2253232|   2250000|       662|       170|     4.62s|
|      76 %|      76 %|   2282750|   2280000|       225|       125|    4.569s|
|      77 %|      77 %|   2312631|   2310000|       108|       123|    4.675s|
|      78 %|      78 %|   2342809|   2340000|       370|        39|     4.56s|
|      79 %|      79 %|   2372698|   2370000|       139|       159|      4.7s|
|      80 %|      80 %|   2402691|   2400000|       171|       120|    5.201s|
|      81 %|      81 %|   2432745|   2430000|       287|        58|     4.91s|
|      82 %|      82 %|   2462430|   2460000|         0|        32|    4.742s|
|      83 %|      83 %|   2494005|   2490000|      1578|        27|    4.644s|
|      84 %|      84 %|   2522513|   2520000|        34|        79|    4.345s|
|      85 %|      85 %|   2552370|   2550000|         0|        10|    4.516s|
|      86 %|      86 %|   2582421|   2580000|         0|        29|    4.458s|
|      87 %|      87 %|   2612533|   2610000|        68|        65|    4.405s|
|      88 %|      88 %|   2642515|   2640000|        87|        28|    4.354s|
|      89 %|      89 %|   2672519|   2670000|        58|        61|    4.405s|
|      90 %|      90 %|   2702413|   2700000|         7|         6|    4.544s|
|      91 %|      91 %|   2733100|   2730000|       619|        81|    4.628s|
|      92 %|      92 %|   2762711|   2760000|       276|        35|    4.519s|
|      93 %|      93 %|   2792781|   2790000|       145|       236|    4.701s|
|      94 %|      94 %|   2822619|   2820000|       214|         5|    4.668s|
|      95 %|      95 %|   2852601|   2850000|        98|       103|    4.639s|
|      96 %|      96 %|   2882919|   2880000|       355|       164|     4.53s|
|      97 %|      97 %|   2912652|   2910000|       102|       150|    4.566s|
|      98 %|      98 %|   2944145|   2940000|      1744|         1|    4.464s|
|      99 %|      99 %|   2972546|   2970000|       100|        46|    4.508s|
|     100 %|     100 %|   3000000|   3000000|         0|         0|     4.75s|
PASS
ok  	github.com/larry618/eval	448.611s

```

## Reviewers
@larry618